### PR TITLE
Fix initial focus behavior: remove CommitsPane auto-focus, explicitly focus branches pane on load

### DIFF
--- a/src/pygitzen/app.py
+++ b/src/pygitzen/app.py
@@ -288,6 +288,10 @@ class PygitzenApp(App):
         self._view_mode = "log"  # Default to log view (branch view)
         # self.refresh_data()
         self.refresh_data_fast()
+
+        # well, textual focuses the first focusable widget
+        # in compose order. Hence, we are making this explicit call to focus on local branches on app load.
+        self.branches_pane.focus()
         
         # Print Cython status to console for debugging (not shown in UI)
         version_info = " (Cython)" if self._using_cython else " (Python)"

--- a/src/pygitzen/app.py
+++ b/src/pygitzen/app.py
@@ -24,7 +24,7 @@ from .config import KeybindingConfig
 from .git_service import (BranchInfo, CommitInfo, FileStatus, GitService,
                           StashInfo, TagInfo)
 from .handlers import BranchActionHandler, CommitActionHandler, FileActionHandler, StashActionHandler, SyncActionHandler
-from .services import BranchService, CommitService, StashService, SyncService, TagService
+from .services import BranchService, CommitService, FileService, StashService, SyncService, TagService
 # Helper functions moved to ui/panes.py
 # Import them if needed for backward compatibility
 # Note: These are used internally in app.py, imported directly from panes module
@@ -150,6 +150,7 @@ class PygitzenApp(App):
             self.repo_path = Path(repo_dir) if isinstance(repo_dir, str) else repo_dir
             self.branch_service = BranchService(self.git, self.repo_path)
             self.commit_service = CommitService(self.git, self.repo_path)
+            self.file_service = FileService(self.repo_path)
             self.sync_service = SyncService(self.git, self.repo_path)
             self.tag_service = TagService(self.git)
             self.stash_service = StashService(self.git)

--- a/src/pygitzen/app.py
+++ b/src/pygitzen/app.py
@@ -3242,6 +3242,10 @@ class PygitzenApp(App):
 
     def show_commit_diff(self, index: int) -> None:
         if 0 <= index < len(self.commits):
+             # Switch to patch view when commit is selected
+            self._view_mode = "patch"
+            self.log_pane.styles.display = "none"
+            self.patch_pane.styles.display = "block"
             import sys
             diff_start = time.perf_counter()
             ci = self.commits[index]

--- a/src/pygitzen/app.py
+++ b/src/pygitzen/app.py
@@ -1058,10 +1058,14 @@ class PygitzenApp(App):
                     self.active_branch = previous_branch
                     # Update BranchesPane selection to match
                     branch_index = branch_names.index(previous_branch)
-                    self.branches_pane.set_branches(self.branches, self.active_branch, self._branch_sync_status_cache)
-                    # Ensure BranchesPane ListView selection matches (set after list is populated)
-                    self.branches_pane.index = branch_index
-                    self.branches_pane.highlighted = branch_index
+                    checked_out_branch = self._get_current_branch_name()
+                    self.branches_pane.set_branches(self.branches, self.active_branch, self._branch_sync_status_cache, checked_out_branch=checked_out_branch)
+                    # Only set index/highlighted if pane has focus
+                    if self.branches_pane.has_focus:
+                        self.branches_pane.index = branch_index
+                        self.branches_pane.highlighted = branch_index
+                        if hasattr(self.branches_pane, '_update_highlighting'):
+                            self.branches_pane._update_highlighting(branch_index)
                 else:
                     # Branch was deleted, fall back to the actual current branch if available,
                     # otherwise use the first branch in the list.
@@ -1072,9 +1076,14 @@ class PygitzenApp(App):
                     else:
                         self.active_branch = self.branches[0].name
                         branch_index = 0
-                    self.branches_pane.set_branches(self.branches, self.active_branch, self._branch_sync_status_cache)
-                    self.branches_pane.index = branch_index
-                    self.branches_pane.highlighted = branch_index
+                    checked_out_branch = self._get_current_branch_name()
+                    self.branches_pane.set_branches(self.branches, self.active_branch, self._branch_sync_status_cache, checked_out_branch=checked_out_branch)
+                    # Only set index/highlighted if pane has focus
+                    if self.branches_pane.has_focus:
+                        self.branches_pane.index = branch_index
+                        self.branches_pane.highlighted = branch_index
+                        if hasattr(self.branches_pane, '_update_highlighting'):
+                            self.branches_pane._update_highlighting(branch_index)
             else:
                 # No previous branch, pick the actual current branch if we can,
                 # otherwise fall back to the first branch (existing behavior).
@@ -1085,9 +1094,14 @@ class PygitzenApp(App):
                 else:
                     self.active_branch = self.branches[0].name
                     branch_index = 0
-                self.branches_pane.set_branches(self.branches, self.active_branch)
-                self.branches_pane.index = branch_index
-                self.branches_pane.highlighted = branch_index
+                checked_out_branch = self._get_current_branch_name()
+                self.branches_pane.set_branches(self.branches, self.active_branch, checked_out_branch=checked_out_branch)
+                # Only set index/highlighted if pane has focus
+                if self.branches_pane.has_focus:
+                    self.branches_pane.index = branch_index
+                    self.branches_pane.highlighted = branch_index
+                    if hasattr(self.branches_pane, '_update_highlighting'):
+                        self.branches_pane._update_highlighting(branch_index)
 
             # Load commits for commits pane (left side) - shows all commits from all branches
             commits_load_start = time.perf_counter()
@@ -1171,10 +1185,14 @@ class PygitzenApp(App):
                     self.active_branch = previous_branch
                     # Update BranchesPane selection to match
                     branch_index = branch_names.index(previous_branch)
-                    self.branches_pane.set_branches(self.branches, self.active_branch, self._branch_sync_status_cache)
-                    # Ensure BranchesPane ListView selection matches (set after list is populated)
-                    self.branches_pane.index = branch_index
-                    self.branches_pane.highlighted = branch_index
+                    checked_out_branch = self._get_current_branch_name()
+                    self.branches_pane.set_branches(self.branches, self.active_branch, self._branch_sync_status_cache, checked_out_branch=checked_out_branch)
+                    # Only set index/highlighted if pane has focus
+                    if self.branches_pane.has_focus:
+                        self.branches_pane.index = branch_index
+                        self.branches_pane.highlighted = branch_index
+                        if hasattr(self.branches_pane, '_update_highlighting'):
+                            self.branches_pane._update_highlighting(branch_index)
                 else:
                     # Branch was deleted, fall back to the actual current branch if available,
                     # otherwise use the first branch.
@@ -1185,9 +1203,14 @@ class PygitzenApp(App):
                     else:
                         self.active_branch = self.branches[0].name
                         branch_index = 0
-                    self.branches_pane.set_branches(self.branches, self.active_branch, self._branch_sync_status_cache)
-                    self.branches_pane.index = branch_index
-                    self.branches_pane.highlighted = branch_index
+                    checked_out_branch = self._get_current_branch_name()
+                    self.branches_pane.set_branches(self.branches, self.active_branch, self._branch_sync_status_cache, checked_out_branch=checked_out_branch)
+                    # Only set index/highlighted if pane has focus
+                    if self.branches_pane.has_focus:
+                        self.branches_pane.index = branch_index
+                        self.branches_pane.highlighted = branch_index
+                        if hasattr(self.branches_pane, '_update_highlighting'):
+                            self.branches_pane._update_highlighting(branch_index)
             else:
                 # No previous branch, prefer the actual current branch if we know it.
                 branch_names = [b.name for b in self.branches]
@@ -1197,7 +1220,7 @@ class PygitzenApp(App):
                 else:
                     self.active_branch = self.branches[0].name
                     branch_index = 0
-                self.branches_pane.set_branches(self.branches, self.active_branch, self._branch_sync_status_cache)
+                self.branches_pane.set_branches(self.branches, self.active_branch, self._branch_sync_status_cache, checked_out_branch=self._get_current_branch_name())
                 self.branches_pane.index = branch_index
                 self.branches_pane.highlighted = branch_index
 
@@ -1229,8 +1252,7 @@ class PygitzenApp(App):
                         lambda: self.branches_pane.set_branches(
                             self.branches, 
                             self.active_branch, 
-                            self._branch_sync_status_cache
-                        )
+                            self._branch_sync_status_cache, checked_out_branch=self._get_current_branch_name())
                     )
                     # Also update status pane - use checked-out branch, not selected branch
                     checked_out_branch = self._get_current_branch_name()
@@ -1276,8 +1298,7 @@ class PygitzenApp(App):
                         lambda: self.branches_pane.set_branches(
                             self.branches, 
                             self.active_branch, 
-                            self._branch_sync_status_cache
-                        )
+                            self._branch_sync_status_cache, checked_out_branch=self._get_current_branch_name())
                     )
             except Exception:
                 pass  # Silently fail if calculation errors
@@ -1317,7 +1338,7 @@ class PygitzenApp(App):
         
         # Update branches pane with sync status (will be updated again when sync status is calculated)
         if self.branches:
-            self.branches_pane.set_branches(self.branches, self.active_branch, self._branch_sync_status_cache)
+            self.branches_pane.set_branches(self.branches, self.active_branch, self._branch_sync_status_cache, checked_out_branch=self._get_current_branch_name())
         
         # Stashes are loaded in background (not here to avoid blocking)
         

--- a/src/pygitzen/config/keybindings.py
+++ b/src/pygitzen/config/keybindings.py
@@ -113,12 +113,14 @@ class KeybindingConfig:
                 Binding("c", "commit", "Commit"),
                 Binding("s", "stash", "Stash"),
                 Binding("S", "stash_options", "Stash Options"),
+                Binding("d", "discard_file", "Discard"),
             ],
             "changes": [
                 Binding("space", "toggle_stage", "Stage"),
                 Binding("c", "commit", "Commit"),
                 Binding("s", "stash", "Stash"),
                 Binding("S", "stash_options", "Stash Options"),
+                Binding("d", "discard_file", "Discard"),
             ],
         }
 

--- a/src/pygitzen/handlers/branch_actions.py
+++ b/src/pygitzen/handlers/branch_actions.py
@@ -68,6 +68,25 @@ class BranchActionHandler:
             # Refresh UI to reflect the checkout
             # This will update branches, status, commits, etc.
             self.app.refresh_data_fast()
+            
+            # Update branches pane selection to highlight the checked-out branch
+            def update_selection():
+                """Update selection to the checked-out branch."""
+                try:
+                    # Find the checked-out branch in the list and select it
+                    for i, branch in enumerate(self.app.branches):
+                        if branch.name == branch_to_checkout:
+                            self.app.branches_pane.index = i
+                            self.app.branches_pane.highlighted = i
+                            # Apply highlighting CSS class
+                            if hasattr(self.app.branches_pane, '_update_highlighting'):
+                                self.app.branches_pane._update_highlighting(i)
+                            break
+                except (AttributeError, IndexError):
+                    pass
+            
+            # Schedule selection update after a short delay to ensure refresh completes
+            self.app.set_timer(0.1, update_selection)
         else:
             # Show error notification
             error_msg = result.get("error", "Unknown error")

--- a/src/pygitzen/handlers/file_actions.py
+++ b/src/pygitzen/handlers/file_actions.py
@@ -142,4 +142,75 @@ class FileActionHandler:
             self.app.patch_pane.show_file_info(file_path, diff_text, stat_text, staged=staged, untracked=untracked)
         else:
             self.app.notify("Patch pane not available", severity="error", timeout=2.0)
+    
+    def discard_file(self, file_path: str, staged: bool = False, untracked: bool = False) -> None:
+        """Discard changes for a file.
+        
+        Args:
+            file_path: Path to the file.
+            staged: Whether to discard staged changes (True) or unstaged changes (False).
+            untracked: Whether the file is untracked.
+        """
+        if not hasattr(self.app, 'file_service'):
+            self.app.notify("File service not available", severity="error", timeout=2.0)
+            return
+        
+        # Get file status to determine what to discard
+        files = self.app.git.get_file_status()
+        file_status = next((f for f in files if f.path == file_path), None)
+        
+        if not file_status:
+            self.app.notify(f"File '{file_path}' not found", severity="error", timeout=2.0)
+            return
+        
+        # Check if file has both staged and unstaged changes
+        # If discarding from StagedPane, only discard staged
+        # If discarding from ChangesPane, discard unstaged (and staged if both exist)
+        is_untracked = file_status.status == "untracked"
+        
+        # For files with both staged and unstaged changes, we need to handle both
+        # Check if file appears in both staged and changes lists
+        has_staged_changes = any(f.path == file_path and f.status in ["staged", "added", "deleted", "renamed", "copied"] for f in files)
+        has_unstaged_changes = any(f.path == file_path and f.status in ["modified", "deleted", "untracked"] for f in files)
+        
+        success = True
+        errors = []
+        
+        # If discarding staged changes, unstage first (git reset)
+        if staged and has_staged_changes:
+            result = self.app.file_service.discard_file_changes(file_path, staged=True, untracked=False)
+            if not result["success"]:
+                success = False
+                errors.append(result.get("error", "Unknown error"))
+        
+        # If discarding unstaged changes (or if file has both and we're discarding from ChangesPane)
+        if (not staged or (has_unstaged_changes and not staged)) and (has_unstaged_changes or is_untracked):
+            result = self.app.file_service.discard_file_changes(file_path, staged=False, untracked=is_untracked)
+            if not result["success"]:
+                success = False
+                errors.append(result.get("error", "Unknown error"))
+        
+        if success:
+            # Clear patch pane if this file is currently displayed
+            if (hasattr(self.app, 'patch_pane') and 
+                hasattr(self.app.patch_pane, '_current_file_path') and
+                self.app.patch_pane._current_file_path == file_path):
+                # Clear the patch pane since file changes are discarded
+                from rich.text import Text
+                self.app.patch_pane.update(Text(f"{file_path} - Changes discarded", style="dim"))
+            
+            # Refresh file status
+            self.app.load_file_status_background()
+            # Show notification
+            change_type = "staged" if staged else "unstaged" if has_unstaged_changes else "untracked"
+            self.app.notify(f"Discarded {change_type} changes: {file_path}", severity="success", timeout=2.0)
+            # Update command log
+            if hasattr(self.app, 'command_log_pane'):
+                self.app.command_log_pane.update_log(f"Discarded {change_type} changes: {file_path}")
+        else:
+            error_msg = "; ".join(errors) if errors else "Unknown error"
+            self.app.notify(f"Failed to discard changes for '{file_path}': {error_msg}", severity="error", timeout=3.0)
+            # Update command log with error
+            if hasattr(self.app, 'command_log_pane'):
+                self.app.command_log_pane.update_log(f"Failed to discard changes for '{file_path}': {error_msg}")
 

--- a/src/pygitzen/handlers/file_actions.py
+++ b/src/pygitzen/handlers/file_actions.py
@@ -170,8 +170,10 @@ class FileActionHandler:
         
         # For files with both staged and unstaged changes, we need to handle both
         # Check if file appears in both staged and changes lists
-        has_staged_changes = any(f.path == file_path and f.status in ["staged", "added", "deleted", "renamed", "copied"] for f in files)
-        has_unstaged_changes = any(f.path == file_path and f.status in ["modified", "deleted", "untracked"] for f in files)
+        # Use the unstaged flag, not just status string, as files with both changes
+        # might have status="staged" but unstaged=True
+        has_staged_changes = any(f.path == file_path and f.staged for f in files)
+        has_unstaged_changes = any(f.path == file_path and (f.unstaged or f.status == "untracked") for f in files)
         
         success = True
         errors = []
@@ -183,8 +185,8 @@ class FileActionHandler:
                 success = False
                 errors.append(result.get("error", "Unknown error"))
         
-        # If discarding unstaged changes (or if file has both and we're discarding from ChangesPane)
-        if (not staged or (has_unstaged_changes and not staged)) and (has_unstaged_changes or is_untracked):
+        # If discarding unstaged changes (from ChangesPane)
+        if not staged and (has_unstaged_changes or is_untracked):
             result = self.app.file_service.discard_file_changes(file_path, staged=False, untracked=is_untracked)
             if not result["success"]:
                 success = False
@@ -201,8 +203,15 @@ class FileActionHandler:
             
             # Refresh file status
             self.app.load_file_status_background()
-            # Show notification
-            change_type = "staged" if staged else "unstaged" if has_unstaged_changes else "untracked"
+            # Show notification - use file_status directly for accurate change type
+            if staged:
+                change_type = "staged"
+            elif is_untracked:
+                change_type = "untracked"
+            elif file_status.unstaged:
+                change_type = "unstaged"
+            else:
+                change_type = "unstaged"  # Default fallback
             self.app.notify(f"Discarded {change_type} changes: {file_path}", severity="success", timeout=2.0)
             # Update command log
             if hasattr(self.app, 'command_log_pane'):

--- a/src/pygitzen/handlers/file_actions.py
+++ b/src/pygitzen/handlers/file_actions.py
@@ -97,4 +97,25 @@ class FileActionHandler:
             # Update command log with error
             if hasattr(self.app, 'command_log_pane'):
                 self.app.command_log_pane.update_log(f"Error unstaging '{file_path}': {str(e)}")
+    
+    def show_file_diff(self, file_path: str, staged: bool = False, untracked: bool = False) -> None:
+        """Show file diff in patch pane.
+        
+        Args:
+            file_path: Path to the file.
+            staged: Whether to show staged diff (True) or unstaged diff (False).
+            untracked: Whether the file is untracked.
+        """
+        if not hasattr(self.app, 'file_service'):
+            self.app.notify("File service not available", severity="error", timeout=2.0)
+            return
+        
+        # Get file diff from service
+        diff_text, stat_text = self.app.file_service.get_file_diff(file_path, staged=staged, untracked=untracked)
+        
+        # Show in patch pane
+        if hasattr(self.app, 'patch_pane') and hasattr(self.app.patch_pane, 'show_file_info'):
+            self.app.patch_pane.show_file_info(file_path, diff_text, stat_text, staged=staged, untracked=untracked)
+        else:
+            self.app.notify("Patch pane not available", severity="error", timeout=2.0)
 

--- a/src/pygitzen/handlers/file_actions.py
+++ b/src/pygitzen/handlers/file_actions.py
@@ -222,4 +222,108 @@ class FileActionHandler:
             # Update command log with error
             if hasattr(self.app, 'command_log_pane'):
                 self.app.command_log_pane.update_log(f"Failed to discard changes for '{file_path}': {error_msg}")
+    
+    def discard_all_staged_changes(self) -> None:
+        """Discard all staged changes in the repository."""
+        if not hasattr(self.app, 'file_service'):
+            self.app.notify("File service not available", severity="error", timeout=2.0)
+            return
+        
+        # Get list of staged files for confirmation
+        files = self.app.git.get_file_status()
+        staged_files = [f for f in files if f.staged]
+        
+        if not staged_files:
+            self.app.notify("No staged changes to discard", severity="warning", timeout=2.0)
+            return
+        
+        # Discard all staged changes
+        result = self.app.file_service.discard_all_staged_changes()
+        
+        if result["success"]:
+            # Refresh file status
+            self.app.load_file_status_background()
+            # Show notification
+            file_count = len(staged_files)
+            self.app.notify(f"Discarded staged changes for {file_count} file(s)", severity="success", timeout=2.0)
+            # Update command log
+            if hasattr(self.app, 'command_log_pane'):
+                self.app.command_log_pane.update_log(f"Discarded staged changes for {file_count} file(s)")
+        else:
+            error_msg = result.get("error", "Unknown error")
+            self.app.notify(f"Failed to discard all staged changes: {error_msg}", severity="error", timeout=3.0)
+            # Update command log with error
+            if hasattr(self.app, 'command_log_pane'):
+                self.app.command_log_pane.update_log(f"Failed to discard all staged changes: {error_msg}")
+    
+    def discard_all_unstaged_changes(self) -> None:
+        """Discard all unstaged changes in the repository."""
+        if not hasattr(self.app, 'file_service'):
+            self.app.notify("File service not available", severity="error", timeout=2.0)
+            return
+        
+        # Get list of unstaged files for confirmation
+        files = self.app.git.get_file_status()
+        unstaged_files = [f for f in files if f.unstaged or (not f.staged and f.status in ["modified", "untracked", "deleted"])]
+        
+        if not unstaged_files:
+            self.app.notify("No unstaged changes to discard", severity="warning", timeout=2.0)
+            return
+        
+        # Discard all unstaged changes
+        result = self.app.file_service.discard_all_unstaged_changes()
+        
+        if result["success"]:
+            # Refresh file status
+            self.app.load_file_status_background()
+            # Show notification
+            file_count = len(unstaged_files)
+            self.app.notify(f"Discarded unstaged changes for {file_count} file(s)", severity="success", timeout=2.0)
+            # Update command log
+            if hasattr(self.app, 'command_log_pane'):
+                self.app.command_log_pane.update_log(f"Discarded unstaged changes for {file_count} file(s)")
+        else:
+            error_msg = result.get("error", "Unknown error")
+            self.app.notify(f"Failed to discard all unstaged changes: {error_msg}", severity="error", timeout=3.0)
+            # Update command log with error
+            if hasattr(self.app, 'command_log_pane'):
+                self.app.command_log_pane.update_log(f"Failed to discard all unstaged changes: {error_msg}")
+    
+    def discard_all_changes(self) -> None:
+        """Discard all staged and unstaged changes in the repository."""
+        if not hasattr(self.app, 'file_service'):
+            self.app.notify("File service not available", severity="error", timeout=2.0)
+            return
+        
+        # Get list of all files with changes for confirmation
+        files = self.app.git.get_file_status()
+        all_changed_files = [f for f in files if f.staged or f.unstaged or f.status in ["modified", "untracked", "deleted"]]
+        
+        if not all_changed_files:
+            self.app.notify("No changes to discard", severity="warning", timeout=2.0)
+            return
+        
+        # Discard all changes
+        result = self.app.file_service.discard_all_changes()
+        
+        if result["success"]:
+            # Clear patch pane
+            if hasattr(self.app, 'patch_pane'):
+                from rich.text import Text
+                self.app.patch_pane.update(Text("All changes discarded", style="dim"))
+            
+            # Refresh file status
+            self.app.load_file_status_background()
+            # Show notification
+            file_count = len(all_changed_files)
+            self.app.notify(f"Discarded all changes for {file_count} file(s)", severity="success", timeout=2.0)
+            # Update command log
+            if hasattr(self.app, 'command_log_pane'):
+                self.app.command_log_pane.update_log(f"Discarded all changes for {file_count} file(s)")
+        else:
+            error_msg = result.get("error", "Unknown error")
+            self.app.notify(f"Failed to discard all changes: {error_msg}", severity="error", timeout=3.0)
+            # Update command log with error
+            if hasattr(self.app, 'command_log_pane'):
+                self.app.command_log_pane.update_log(f"Failed to discard all changes: {error_msg}")
 

--- a/src/pygitzen/handlers/file_actions.py
+++ b/src/pygitzen/handlers/file_actions.py
@@ -43,6 +43,16 @@ class FileActionHandler:
             )
             
             if result.returncode == 0:
+                # Update patch pane if this file is currently displayed
+                if (hasattr(self.app, 'patch_pane') and 
+                    hasattr(self.app.patch_pane, '_current_file_path') and
+                    self.app.patch_pane._current_file_path == file_path and
+                    not self.app.patch_pane._current_file_staged):
+                    # File is currently shown and was unstaged, now it's staged - update patch pane
+                    if hasattr(self.app, 'file_service'):
+                        diff_text, stat_text = self.app.file_service.get_file_diff(file_path, staged=True, untracked=False)
+                        self.app.patch_pane.show_file_info(file_path, diff_text, stat_text, staged=True, untracked=False)
+                
                 # Refresh file status
                 self.app.load_file_status_background()
                 # Show notification
@@ -79,6 +89,20 @@ class FileActionHandler:
             )
             
             if result.returncode == 0:
+                # Update patch pane if this file is currently displayed
+                if (hasattr(self.app, 'patch_pane') and 
+                    hasattr(self.app.patch_pane, '_current_file_path') and
+                    self.app.patch_pane._current_file_path == file_path and
+                    self.app.patch_pane._current_file_staged):
+                    # File is currently shown and was staged, now it's unstaged - update patch pane
+                    if hasattr(self.app, 'file_service'):
+                        # Check if file is untracked
+                        files = self.app.git.get_file_status()
+                        file_status = next((f for f in files if f.path == file_path), None)
+                        untracked = file_status.status == "untracked" if file_status else False
+                        diff_text, stat_text = self.app.file_service.get_file_diff(file_path, staged=False, untracked=untracked)
+                        self.app.patch_pane.show_file_info(file_path, diff_text, stat_text, staged=False, untracked=untracked)
+                
                 # Refresh file status
                 self.app.load_file_status_background()
                 # Show notification

--- a/src/pygitzen/services/__init__.py
+++ b/src/pygitzen/services/__init__.py
@@ -2,6 +2,7 @@
 
 from .branch_service import BranchService
 from .commit_service import CommitService
+from .file_service import FileService
 from .sync_service import SyncService
 from .tag_service import TagService
 from .stash_service import StashService
@@ -9,6 +10,7 @@ from .stash_service import StashService
 __all__ = [
     "BranchService",
     "CommitService",
+    "FileService",
     "SyncService",
     "TagService",
     "StashService",

--- a/src/pygitzen/services/file_service.py
+++ b/src/pygitzen/services/file_service.py
@@ -133,4 +133,139 @@ class FileService:
                 return {"success": False, "error": error_msg}
         except Exception as e:
             return {"success": False, "error": str(e)}
+    
+    def discard_all_staged_changes(self) -> dict:
+        """Discard all staged changes in the repository.
+        
+        Returns:
+            Dictionary with 'success' (bool) and 'error' (str) keys.
+        """
+        repo_path_str = str(self.repo_path)
+        
+        try:
+            result = subprocess.run(
+                ["git", "reset", "--"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                cwd=repo_path_str,
+            )
+            
+            if result.returncode == 0:
+                return {"success": True, "error": ""}
+            else:
+                error_msg = result.stderr.strip() or result.stdout.strip() or "Unknown error"
+                return {"success": False, "error": error_msg}
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+    
+    def discard_all_unstaged_changes(self) -> dict:
+        """Discard all unstaged changes in the repository.
+        
+        This includes:
+        - Modified tracked files (restored to HEAD)
+        - Deleted tracked files (restored)
+        - Untracked files (removed)
+        
+        Returns:
+            Dictionary with 'success' (bool) and 'error' (str) keys.
+        """
+        repo_path_str = str(self.repo_path)
+        
+        try:
+            # First, restore tracked files to HEAD state
+            result = subprocess.run(
+                ["git", "checkout", "--", "."],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                cwd=repo_path_str,
+            )
+            
+            if result.returncode != 0:
+                error_msg = result.stderr.strip() or result.stdout.strip() or "Unknown error"
+                return {"success": False, "error": error_msg}
+            
+            # Then, remove untracked files and directories
+            clean_result = subprocess.run(
+                ["git", "clean", "-fd"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                cwd=repo_path_str,
+            )
+            
+            if clean_result.returncode == 0:
+                return {"success": True, "error": ""}
+            else:
+                # If clean fails but checkout succeeded, still report success
+                # but include warning about untracked files
+                error_msg = clean_result.stderr.strip() or clean_result.stdout.strip() or ""
+                if error_msg:
+                    return {"success": True, "error": f"Untracked files cleanup warning: {error_msg}"}
+                return {"success": True, "error": ""}
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+    
+    def discard_all_changes(self) -> dict:
+        """Discard all staged and unstaged changes in the repository.
+        
+        This includes:
+        - Staged changes (unstaged via git reset)
+        - Modified tracked files (restored to HEAD)
+        - Deleted tracked files (restored)
+        - Untracked files (removed)
+        
+        Returns:
+            Dictionary with 'success' (bool) and 'error' (str) keys.
+        """
+        repo_path_str = str(self.repo_path)
+        
+        try:
+            # First discard staged changes
+            reset_result = subprocess.run(
+                ["git", "reset", "--"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                cwd=repo_path_str,
+            )
+            
+            if reset_result.returncode != 0:
+                error_msg = reset_result.stderr.strip() or reset_result.stdout.strip() or "Unknown error"
+                return {"success": False, "error": f"Failed to discard staged changes: {error_msg}"}
+            
+            # Then discard unstaged changes (restore tracked files to HEAD)
+            checkout_result = subprocess.run(
+                ["git", "checkout", "--", "."],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                cwd=repo_path_str,
+            )
+            
+            if checkout_result.returncode != 0:
+                error_msg = checkout_result.stderr.strip() or checkout_result.stdout.strip() or "Unknown error"
+                return {"success": False, "error": f"Failed to discard unstaged changes: {error_msg}"}
+            
+            # Finally, remove untracked files and directories
+            clean_result = subprocess.run(
+                ["git", "clean", "-fd"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                cwd=repo_path_str,
+            )
+            
+            if clean_result.returncode == 0:
+                return {"success": True, "error": ""}
+            else:
+                # If clean fails but reset/checkout succeeded, still report success
+                # but include warning about untracked files
+                error_msg = clean_result.stderr.strip() or clean_result.stdout.strip() or ""
+                if error_msg:
+                    return {"success": True, "error": f"Untracked files cleanup warning: {error_msg}"}
+                return {"success": True, "error": ""}
+        except Exception as e:
+            return {"success": False, "error": str(e)}
 

--- a/src/pygitzen/services/file_service.py
+++ b/src/pygitzen/services/file_service.py
@@ -82,4 +82,55 @@ class FileService:
             return (diff_text, stat_text)
         except Exception:
             return ("", "")
+    
+    def discard_file_changes(self, file_path: str, staged: bool = False, untracked: bool = False) -> dict:
+        """Discard changes for a file.
+        
+        Args:
+            file_path: Path to the file.
+            staged: Whether to discard staged changes (True) or unstaged changes (False).
+            untracked: Whether the file is untracked.
+        
+        Returns:
+            Dictionary with 'success' (bool) and 'error' (str) keys.
+        """
+        repo_path_str = str(self.repo_path)
+        
+        try:
+            # For untracked files, remove the file
+            if untracked:
+                from pathlib import Path
+                full_path = self.repo_path / file_path
+                if full_path.exists():
+                    full_path.unlink()
+                    return {"success": True, "error": ""}
+                else:
+                    return {"success": False, "error": "File does not exist"}
+            
+            # For staged changes, use git reset
+            if staged:
+                result = subprocess.run(
+                    ["git", "reset", "--", file_path],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                    cwd=repo_path_str,
+                )
+            else:
+                # For unstaged changes, use git checkout
+                result = subprocess.run(
+                    ["git", "checkout", "--", file_path],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                    cwd=repo_path_str,
+                )
+            
+            if result.returncode == 0:
+                return {"success": True, "error": ""}
+            else:
+                error_msg = result.stderr.strip() or result.stdout.strip() or "Unknown error"
+                return {"success": False, "error": error_msg}
+        except Exception as e:
+            return {"success": False, "error": str(e)}
 

--- a/src/pygitzen/services/file_service.py
+++ b/src/pygitzen/services/file_service.py
@@ -1,0 +1,85 @@
+"""File service for file-related operations.
+
+Pure business logic - no UI dependencies.
+"""
+
+import subprocess
+from pathlib import Path
+from typing import Tuple
+
+
+class FileService:
+    """Service for file-related operations."""
+
+    def __init__(self, repo_path: Path | str) -> None:
+        """Initialize file service.
+        
+        Args:
+            repo_path: Repository root path.
+        """
+        self.repo_path = Path(repo_path) if isinstance(repo_path, str) else repo_path
+
+    def get_file_diff(self, file_path: str, staged: bool = False, untracked: bool = False) -> Tuple[str, str]:
+        """Get diff for a file.
+        
+        Args:
+            file_path: Path to the file.
+            staged: Whether to show staged diff (default: False for unstaged).
+            untracked: Whether the file is untracked (default: False).
+        
+        Returns:
+            Tuple of (diff_text, stat_text). Both are empty strings on error.
+        """
+        repo_path_str = str(self.repo_path)
+        
+        try:
+            # For untracked files, use --no-index to compare against /dev/null
+            if untracked and not staged:
+                # Show untracked file as new file
+                result = subprocess.run(
+                    ["git", "diff", "--no-index", "--", "/dev/null", file_path],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                    cwd=repo_path_str,
+                )
+            else:
+                # For tracked files, use regular diff
+                cmd = ["git", "diff"]
+                if staged:
+                    cmd.append("--cached")
+                cmd.extend(["--", file_path])
+                
+                result = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                    cwd=repo_path_str,
+                )
+            
+            if result.returncode == 0:
+                diff_text = result.stdout
+            else:
+                # For untracked files, git diff --no-index returns non-zero
+                # but still outputs the diff, so check stdout
+                if untracked and result.stdout:
+                    diff_text = result.stdout
+                else:
+                    diff_text = ""
+            
+            # Get stat summary
+            stat_result = subprocess.run(
+                ["git", "diff", "--stat"] + (["--cached"] if staged else []) + ["--", file_path],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                cwd=repo_path_str,
+            )
+            
+            stat_text = stat_result.stdout if stat_result.returncode == 0 else ""
+            
+            return (diff_text, stat_text)
+        except Exception:
+            return ("", "")
+

--- a/src/pygitzen/styles/app.tcss
+++ b/src/pygitzen/styles/app.tcss
@@ -274,6 +274,18 @@ ListItem {
     text-style: bold;
 }
 
+#branches-pane ListItem.highlighted-branch {
+    background: #357ABD;
+    color: #ffffff;
+    text-style: bold;
+}
+
+#branches-pane ListItem.highlighted-branch:focus {
+    background: #2f6aa3;
+    color: #ffffff;
+    text-style: bold;
+}
+
 /* Selected/highlighted item styling for stash pane */
 #stash-pane ListItem.--highlight {
     background: #357ABD; /* blue for strong contrast */
@@ -314,6 +326,31 @@ ListItem {
     color: white;
 }
 
+/* Highlighted file styling for staged and changes panes */
+#staged-pane ListItem.highlighted-file {
+    background: #357ABD;
+    color: #ffffff;
+    text-style: bold;
+}
+
+#staged-pane ListItem.highlighted-file:focus {
+    background: #2f6aa3;
+    color: #ffffff;
+    text-style: bold;
+}
+
+#changes-pane ListItem.highlighted-file {
+    background: #357ABD;
+    color: #ffffff;
+    text-style: bold;
+}
+
+#changes-pane ListItem.highlighted-file:focus {
+    background: #2f6aa3;
+    color: #ffffff;
+    text-style: bold;
+}
+
 Panel {
     padding: 1;
     background: #1e1e1e;
@@ -338,11 +375,26 @@ Static {
     background: transparent;
     color: #ffffff;
 }
+
+#branches-pane ListItem.highlighted-branch > Static {
+    background: transparent;
+    color: #ffffff;
+}
 #stash-pane ListItem.--highlight > Static {
     background: transparent;
     color: #ffffff;
 }
 #stash-pane ListItem.highlighted-stash > Static {
+    background: transparent;
+    color: #ffffff;
+}
+
+#staged-pane ListItem.highlighted-file > Static {
+    background: transparent;
+    color: #ffffff;
+}
+
+#changes-pane ListItem.highlighted-file > Static {
     background: transparent;
     color: #ffffff;
 }

--- a/src/pygitzen/styles/app.tcss
+++ b/src/pygitzen/styles/app.tcss
@@ -399,6 +399,42 @@ Static {
     color: #ffffff;
 }
 
+/* Selected/highlighted item styling for remotes pane */
+#remotes-pane ListItem.highlighted-remote {
+    background: #357ABD;
+    color: #ffffff;
+    text-style: bold;
+}
+
+#remotes-pane ListItem.highlighted-remote:focus {
+    background: #2f6aa3;
+    color: #ffffff;
+    text-style: bold;
+}
+
+#remotes-pane ListItem.highlighted-remote > Static {
+    background: transparent;
+    color: #ffffff;
+}
+
+/* Selected/highlighted item styling for tags pane */
+#tags-pane ListItem.highlighted-tag {
+    background: #357ABD;
+    color: #ffffff;
+    text-style: bold;
+}
+
+#tags-pane ListItem.highlighted-tag:focus {
+    background: #2f6aa3;
+    color: #ffffff;
+    text-style: bold;
+}
+
+#tags-pane ListItem.highlighted-tag > Static {
+    background: transparent;
+    color: #ffffff;
+}
+
 /* Selected/highlighted item styling for delete branch dialog */
 #delete-branch-dialog #options-list ListItem.--highlight {
     background: #357ABD; /* blue for strong contrast */

--- a/src/pygitzen/ui/dialogs.py
+++ b/src/pygitzen/ui/dialogs.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Optional
 
+from rich import style
 from textual.screen import ModalScreen
 from textual.widgets import Input, Label, Button, Static, Link, ListView, ListItem, TextArea
 from textual.containers import Container, Horizontal, Vertical
@@ -2085,3 +2086,508 @@ class DiscardFileDialog(ModalScreen[bool]):
         """Dismiss the dialog when Escape is pressed."""
         self.dismiss(False)
 
+
+class DiscardOptionsDialog(ModalScreen[str | None]):
+    """Menu dialog for discard options with radio button interface."""
+
+    BINDINGS = [
+        Binding("escape", "dismiss", "Close", show=False),
+        Binding("enter", "confirm", "Confirm", show=False),
+    ]
+
+    DEFAULT_CSS = """
+    DiscardOptionsDialog {
+        align: center middle;
+    }
+
+    DiscardOptionsDialog #discard-options-dialog {
+        width: 75%;
+        min-width: 65;
+        max-width: 85;
+        height: auto;
+        min-height: 18;
+        background: $surface;
+        border: thick $primary;
+        layout: vertical;
+        padding: 2;
+    }
+
+    DiscardOptionsDialog #discard-options-header {
+        width: 100%;
+        height: auto;
+        text-align: center;
+        text-style: bold;
+        color: $text;
+        margin-bottom: 2;
+        padding-bottom: 1;
+        border-bottom: solid $primary;
+    }
+
+    DiscardOptionsDialog #discard-options-subtitle {
+        width: 100%;
+        height: auto;
+        text-align: center;
+        color: $text-muted;
+        margin-bottom: 2;
+    }
+
+    DiscardOptionsDialog #radio-container {
+        width: 100%;
+        height: auto;
+        layout: vertical;
+        margin-bottom: 2;
+        border: solid $primary 30%;
+    }
+
+    DiscardOptionsDialog .radio-option {
+        width: 100%;
+        height: auto;
+        padding: 0 1;
+        margin-bottom: 0;
+        border: none;
+        background: $surface;
+        layout: horizontal;
+        align: left middle;
+    }
+
+    DiscardOptionsDialog .radio-option:focus {
+        background: $primary 10%;
+    }
+
+    DiscardOptionsDialog .radio-option:hover {
+        background: $primary 10%;
+    }
+
+    DiscardOptionsDialog .radio-option.selected {
+        background: $primary 15%;
+    }
+
+    DiscardOptionsDialog .radio-option.selected:focus {
+        background: $primary 20%;
+    }
+
+    DiscardOptionsDialog .radio-option-row {
+        width: 100%;
+        height: auto;
+        layout: horizontal;
+        align: left middle;
+    }
+
+    DiscardOptionsDialog .radio-indicator {
+        width: 3;
+        height: 1;
+        margin-right: 1;
+        text-align: center;
+        content-align: center middle;
+    }
+
+    DiscardOptionsDialog .radio-indicator.selected {
+        color: $primary;
+    }
+
+    DiscardOptionsDialog .radio-label {
+        width: 1fr;
+        color: $text;
+        text-style: bold;
+    }
+
+    DiscardOptionsDialog .radio-label.warning {
+        color: $warning;
+    }
+
+    DiscardOptionsDialog .radio-description {
+        width: 1fr;
+        color: $text-muted;
+        margin-left: 1;
+    }
+
+    DiscardOptionsDialog .radio-description.warning {
+        color: $warning;
+    }
+
+    DiscardOptionsDialog #discard-options-info {
+        width: 100%;
+        height: auto;
+        text-align: center;
+        color: $text-muted;
+        margin-bottom: 2;
+    }
+
+    DiscardOptionsDialog #discard-options-button-container {
+        width: 100%;
+        layout: horizontal;
+        align: center middle;
+        height: auto;
+    }
+
+    DiscardOptionsDialog #cancel-button {
+        margin-right: 1;
+    }
+
+    DiscardOptionsDialog #confirm-button {
+        min-width: 15;
+    }
+    """
+
+    def __init__(self, file_path: str, pane_type: str, has_staged: bool = False, has_unstaged: bool = False) -> None:
+        """Initialize discard options dialog.
+        
+        Args:
+            file_path: Path to the selected file.
+            pane_type: Either "staged" or "changes" to determine which options to show.
+            has_staged: Whether there are any staged files in the repository.
+            has_unstaged: Whether there are any unstaged files in the repository.
+        """
+        super().__init__()
+        self.file_path = file_path
+        self.pane_type = pane_type
+        self.selected_option: str | None = None
+        
+        # Build options based on pane type
+        if pane_type == "staged":
+            self.options = [
+                ("file_staged", f"Discard staged changes in {file_path}", "Discard only staged changes for this file"),
+                ("all_staged", "Discard all staged changes", "Discard staged changes for ALL files"),
+            ]
+            # Only show "discard all" option if there are both staged and unstaged files
+            if has_staged and has_unstaged:
+                self.options.append(("all_both", "Discard all staged and unstaged changes", "Discard ALL changes for ALL files"))
+        else:  # changes pane
+            self.options = [
+                ("file_unstaged", f"Discard unstaged changes in {file_path}", "Discard only unstaged changes for this file"),
+                ("all_unstaged", "Discard all unstaged changes", "Discard unstaged changes for ALL files"),
+            ]
+            # Only show "discard all" option if there are both staged and unstaged files
+            if has_staged and has_unstaged:
+                self.options.append(("all_both", "Discard all staged and unstaged changes", "Discard ALL changes for ALL files"))
+
+    def compose(self):
+        """Compose the menu."""
+        with Container(id="discard-options-dialog"):
+            yield Static("Discard Options", id="discard-options-header")
+            yield Static("Select a discard option", id="discard-options-subtitle")
+            
+            with Container(id="radio-container"):
+                for option_id, label, description in self.options:
+                    is_warning = option_id in ["all_staged", "all_unstaged", "all_both"]
+                    with Container(classes="radio-option", id=f"option-{option_id}") as option_container:
+                        option_container.can_focus = True
+                        yield Static("○", classes="radio-indicator", id=f"indicator-{option_id}")
+                        label_widget = Static(label, classes="radio-label", id=f"label-{option_id}")
+                        if is_warning:
+                            label_widget.add_class("warning")
+                        yield label_widget
+                        desc_widget = Static(f"  •  {description}", classes="radio-description")
+                        if is_warning:
+                            desc_widget.add_class("warning")
+                        yield desc_widget
+            
+            yield Static("Use ↑↓ to navigate, Enter to confirm, or Escape to cancel", id="discard-options-info")
+            
+            with Container(id="discard-options-button-container"):
+                yield Button("Cancel", id="cancel-button", variant="default")
+                yield Button("Confirm", id="confirm-button", variant="primary")
+
+    def on_mount(self) -> None:
+        """Focus the first option when mounted."""
+        # Select first option by default
+        if self.options:
+            self._select_option(self.options[0][0])
+            # Focus the first option container
+            try:
+                first_option = self.query_one(f"#option-{self.options[0][0]}")
+                first_option.focus()
+            except Exception:
+                pass
+
+    def on_key(self, event) -> None:
+        """Handle keyboard navigation."""
+        if event.key == "up":
+            self._navigate(-1)
+            event.prevent_default()
+            event.stop()
+        elif event.key == "down":
+            self._navigate(1)
+            event.prevent_default()
+            event.stop()
+        elif event.key == "enter" or event.key == " ":
+            if self.selected_option:
+                self.dismiss(self.selected_option)
+            event.prevent_default()
+            event.stop()
+
+    def _navigate(self, direction: int) -> None:
+        """Navigate between options."""
+        current_index = 0
+        if self.selected_option:
+            for i, (option_id, _, _) in enumerate(self.options):
+                if option_id == self.selected_option:
+                    current_index = i
+                    break
+        
+        new_index = (current_index + direction) % len(self.options)
+        new_option_id = self.options[new_index][0]
+        self._select_option(new_option_id)
+        
+        try:
+            option = self.query_one(f"#option-{new_option_id}")
+            option.focus()
+        except Exception:
+            pass
+
+    def _select_option(self, option_id: str) -> None:
+        """Select an option."""
+        # Deselect previous
+        if self.selected_option:
+            try:
+                prev_option = self.query_one(f"#option-{self.selected_option}")
+                prev_indicator = self.query_one(f"#indicator-{self.selected_option}")
+                prev_option.remove_class("selected")
+                prev_indicator.remove_class("selected")
+                prev_indicator.update("○")
+            except Exception:
+                pass
+        
+        # Select new
+        self.selected_option = option_id
+        try:
+            option = self.query_one(f"#option-{option_id}")
+            indicator = self.query_one(f"#indicator-{option_id}")
+            option.add_class("selected")
+            indicator.add_class("selected")
+            indicator.update("●")
+        except Exception:
+            pass
+
+    def on_click(self, event) -> None:
+        """Handle click on option."""
+        # Check if click is within the dialog
+        try:
+            dialog = self.query_one("#discard-options-dialog")
+            dialog_region = dialog.region
+            
+            # If click is outside dialog, just ignore it
+            if not (dialog_region.x <= event.x < dialog_region.x + dialog_region.width and
+                    dialog_region.y <= event.y < dialog_region.y + dialog_region.height):
+                return
+            
+            # Get the widget at the click coordinates
+            clicked_widget = self.screen.get_widget_at(event.x, event.y)
+            if clicked_widget is None:
+                return
+            
+            # Find the option container by traversing up the DOM
+            current = clicked_widget
+            while current and current != self:
+                if hasattr(current, 'has_class') and current.has_class("radio-option"):
+                    if hasattr(current, 'id') and current.id:
+                        option_id = current.id.replace("option-", "")
+                        self._select_option(option_id)
+                        current.focus()
+                        return
+                current = getattr(current, 'parent', None)
+        except Exception:
+            # If we can't determine what was clicked, just ignore
+            pass
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Handle button press."""
+        if event.button.id == "confirm-button":
+            if self.selected_option:
+                self.dismiss(self.selected_option)
+        else:
+            self.dismiss(None)
+
+    def action_confirm(self) -> None:
+        """Confirm selection when Enter is pressed."""
+        if self.selected_option:
+            self.dismiss(self.selected_option)
+
+    def action_dismiss(self) -> None:
+        """Dismiss the modal."""
+        self.dismiss(None)
+
+
+class DiscardAllConfirmDialog(ModalScreen[bool]):
+    """Confirmation dialog for discarding all changes with file list."""
+
+    BINDINGS = [
+        Binding("escape", "dismiss", "Cancel", show=False),
+    ]
+
+    DEFAULT_CSS = """
+    DiscardAllConfirmDialog {
+        align: center middle;
+    }
+
+    DiscardAllConfirmDialog #discard-all-confirm-dialog {
+        width: 75%;
+        min-width: 65;
+        max-width: 85;
+        height: auto;
+        min-height: 20;
+        max-height: 80%;
+        background: $surface;
+        border: thick $warning;
+        layout: vertical;
+        padding: 2;
+    }
+
+    DiscardAllConfirmDialog #discard-all-confirm-header {
+        width: 100%;
+        height: auto;
+        text-align: center;
+        text-style: bold;
+        color: $warning;
+        margin-bottom: 2;
+        padding-bottom: 1;
+        border-bottom: solid $warning;
+    }
+
+    DiscardAllConfirmDialog #discard-all-confirm-subtitle {
+        width: 100%;
+        height: auto;
+        text-align: center;
+        color: $text-muted;
+        margin-bottom: 2;
+    }
+
+    DiscardAllConfirmDialog #discard-all-confirm-message-container {
+        width: 100%;
+        height: auto;
+        layout: vertical;
+        margin-bottom: 2;
+        padding: 1;
+        border: solid $warning;
+        background: $panel;
+    }
+
+    DiscardAllConfirmDialog #discard-all-confirm-message {
+        width: 100%;
+        height: auto;
+        color: $text;
+        text-align: center;
+        margin-bottom: 1;
+    }
+
+    DiscardAllConfirmDialog #discard-all-confirm-file-count {
+        width: 100%;
+        height: auto;
+        color: $accent;
+        text-style: bold;
+        text-align: center;
+        margin-bottom: 1;
+    }
+
+    DiscardAllConfirmDialog #discard-all-confirm-file-list {
+        width: 100%;
+        height: auto;
+        max-height: 20;
+        overflow-y: auto;
+        padding: 1;
+        background: $background;
+        border: solid $primary;
+        border-title-align: left;
+        border-title-color: $accent;
+    }
+
+    DiscardAllConfirmDialog #discard-all-confirm-warning {
+        width: 100%;
+        height: auto;
+        color: $warning;
+        text-align: center;
+        margin-top: 1;
+        text-style: italic;
+        text-style: bold;
+    }
+
+    DiscardAllConfirmDialog #discard-all-confirm-button-container {
+        width: 100%;
+        layout: horizontal;
+        align: center middle;
+        height: auto;
+        margin-top: 1;
+    }
+
+    DiscardAllConfirmDialog #cancel-button {
+        margin-right: 1;
+        min-width: 12;
+    }
+
+    DiscardAllConfirmDialog #discard-button {
+        margin-left: 1;
+        min-width: 12;
+    }
+    """
+
+    def __init__(
+        self,
+        title: str,
+        message: str,
+        file_list: list[str],
+        file_count: int,
+    ) -> None:
+        """Initialize discard all confirmation dialog.
+        
+        Args:
+            title: Dialog title.
+            message: Confirmation message.
+            file_list: List of file paths that will be affected.
+            file_count: Total number of files.
+        """
+        super().__init__()
+        self.title_text = title
+        self.message_text = message
+        self.file_list = file_list
+        self.file_count = file_count
+
+    def compose(self):
+        """Compose dialog widgets."""
+        with Container(id="discard-all-confirm-dialog"):
+            yield Static(self.title_text, id="discard-all-confirm-header")
+            yield Static("Please confirm this action", id="discard-all-confirm-subtitle")
+            
+            with Container(id="discard-all-confirm-message-container"):
+                yield Static(self.message_text, id="discard-all-confirm-message")
+                yield Static(f"Affected files: {self.file_count}", id="discard-all-confirm-file-count")
+                
+                if self.file_list:
+                    with Container(id="discard-all-confirm-file-list") as file_list_container:
+                        file_list_container.border_title = "Files to be affected"
+                        # Show file list (limit to first 20 for display)
+                        display_files = self.file_list[:20]
+                        for file_path in display_files:
+                            from rich.text import Text
+                            file_text = Text(f"  • {file_path}", style="dim white")
+                            yield Static(file_text)
+                        if len(self.file_list) > 20:
+                            from rich.text import Text
+                            more_text = Text(f"  ... and {len(self.file_list) - 20} more file(s)", style="dim white")
+                            yield Static(more_text)
+                
+                yield Static(
+                    "Warning: This action cannot be undone.",
+                    id="discard-all-confirm-warning"
+                )
+            
+            with Container(id="discard-all-confirm-button-container"):
+                yield Button("Cancel", id="cancel-button", variant="default")
+                yield Button("Discard All", id="discard-button", variant="error")
+
+    def on_mount(self) -> None:
+        """Focus discard button when mounted."""
+        try:
+            self.query_one("#discard-button", Button).focus()
+        except Exception:
+            pass
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Handle button presses."""
+        if event.button.id == "discard-button":
+            self.dismiss(True)
+        elif event.button.id == "cancel-button":
+            self.dismiss(False)
+
+    def action_dismiss(self) -> None:
+        """Dismiss the dialog when Escape is pressed."""
+        self.dismiss(False)

--- a/src/pygitzen/ui/dialogs.py
+++ b/src/pygitzen/ui/dialogs.py
@@ -1909,3 +1909,179 @@ class StashConfirmDialog(ModalScreen[bool]):
         """Dismiss the dialog when Escape is pressed."""
         self.dismiss(False)
 
+
+class DiscardFileDialog(ModalScreen[bool]):
+    """Confirmation dialog for discarding file changes."""
+
+    BINDINGS = [
+        Binding("escape", "dismiss", "Cancel", show=False),
+    ]
+
+    DEFAULT_CSS = """
+    DiscardFileDialog {
+        align: center middle;
+    }
+
+    DiscardFileDialog #discard-file-dialog {
+        width: 70%;
+        min-width: 55;
+        max-width: 80;
+        height: auto;
+        min-height: 12;
+        background: $surface;
+        border: thick $primary;
+        layout: vertical;
+        padding: 2;
+    }
+
+    DiscardFileDialog #discard-file-header {
+        width: 100%;
+        height: auto;
+        text-align: center;
+        text-style: bold;
+        color: $text;
+        margin-bottom: 2;
+        padding-bottom: 1;
+        border-bottom: solid $primary;
+    }
+
+    DiscardFileDialog #discard-file-subtitle {
+        width: 100%;
+        height: auto;
+        text-align: center;
+        color: $text-muted;
+        margin-bottom: 2;
+    }
+
+    DiscardFileDialog #discard-file-message-container {
+        width: 100%;
+        height: auto;
+        layout: vertical;
+        margin-bottom: 2;
+        padding: 1;
+        border: solid $primary;
+        background: $panel;
+    }
+
+    DiscardFileDialog #discard-file-message {
+        width: 100%;
+        height: auto;
+        color: $text;
+        text-align: center;
+    }
+
+    DiscardFileDialog #discard-file-info {
+        width: 100%;
+        height: auto;
+        margin-top: 1;
+        padding: 1;
+        background: $background;
+        border: solid $primary;
+        border-title-align: left;
+        border-title-color: $accent;
+    }
+
+    DiscardFileDialog #discard-file-name {
+        width: 100%;
+        height: auto;
+        color: $accent;
+        text-style: bold;
+        text-align: center;
+        margin-bottom: 1;
+    }
+
+    DiscardFileDialog #discard-file-warning {
+        width: 100%;
+        height: auto;
+        color: $warning;
+        text-align: center;
+        margin-top: 1;
+        text-style: italic;
+    }
+
+    DiscardFileDialog #discard-file-button-container {
+        width: 100%;
+        layout: horizontal;
+        align: center middle;
+        height: auto;
+        margin-top: 1;
+    }
+
+    DiscardFileDialog #cancel-button {
+        margin-right: 1;
+        min-width: 12;
+    }
+
+    DiscardFileDialog #discard-button {
+        margin-left: 1;
+        min-width: 12;
+    }
+    """
+
+    def __init__(
+        self,
+        file_path: str,
+        change_type: str = "changes",
+        title: str = "Discard Changes",
+    ) -> None:
+        """Initialize discard file confirmation dialog.
+        
+        Args:
+            file_path: Path to the file.
+            change_type: Type of changes ("staged", "unstaged", "untracked", or "changes").
+            title: Dialog title.
+        """
+        super().__init__()
+        self.file_path = file_path
+        self.change_type = change_type
+        self.title_text = title
+
+    def compose(self):
+        """Compose dialog widgets."""
+        with Container(id="discard-file-dialog"):
+            yield Static(self.title_text, id="discard-file-header")
+            yield Static("Please confirm this action", id="discard-file-subtitle")
+            
+            with Container(id="discard-file-message-container"):
+                change_desc = {
+                    "staged": "staged changes",
+                    "unstaged": "unstaged changes",
+                    "untracked": "untracked file",
+                    "changes": "changes"
+                }.get(self.change_type, "changes")
+                
+                yield Static(
+                    f"Are you sure you want to discard {change_desc} for this file?",
+                    id="discard-file-message"
+                )
+                
+                with Container(id="discard-file-info"):
+                    yield Static(self.file_path, id="discard-file-name")
+                
+                yield Static(
+                    "This action cannot be undone.",
+                    id="discard-file-warning"
+                )
+            
+            with Container(id="discard-file-button-container"):
+                yield Button("Cancel", id="cancel-button", variant="default")
+                yield Button("Discard", id="discard-button", variant="error")
+
+    def on_mount(self) -> None:
+        """Focus discard button when mounted."""
+        try:
+            self.query_one("#discard-button", Button).focus()
+        except Exception:
+            pass
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Handle button presses."""
+        if event.button.id == "discard-button":
+            self.dismiss(True)
+        elif event.button.id == "cancel-button":
+            self.dismiss(False)
+
+    def action_dismiss(self) -> None:
+        """Dismiss the dialog when Escape is pressed."""
+        self.dismiss(False)
+

--- a/src/pygitzen/ui/panes.py
+++ b/src/pygitzen/ui/panes.py
@@ -222,6 +222,7 @@ class StagedPane(ListView):
         self.border_title = "Staged Changes"
         self.show_cursor = False
         self._files: list[FileStatus] = []  # Store files for access by index
+        self._last_highlighted: int | None = None  # Track highlighted changes
     
     def update_files(self, files: list[FileStatus]) -> None:
         """Update the staged files list."""
@@ -235,6 +236,7 @@ class StagedPane(ListView):
         
         # Store filtered files for access by index
         self._files = staged_files
+        self._last_highlighted = None  # Reset highlighting when files are updated
         
         if not staged_files:
             from rich.text import Text
@@ -315,12 +317,15 @@ class StagedPane(ListView):
     
     def watch_index(self, index: int | None) -> None:
         """Watch for index changes and auto-show file diff."""
+        # Update highlighting for mouse clicks
+        self._update_highlighting(index)
+        
         if index is not None and 0 <= index < len(self._files):
             file_status = self._files[index]
             file_path = file_status.path
             
-            # Determine if file is staged and untracked
-            staged = file_status.staged
+            # For StagedPane, all files are staged
+            staged = True
             untracked = file_status.status == "untracked"
             
             # Get app instance and show file diff
@@ -335,6 +340,73 @@ class StagedPane(ListView):
                 
                 # Show file diff
                 app.file_actions.show_file_diff(file_path, staged=staged, untracked=untracked)
+            
+            # Scroll to selected item to ensure it's visible
+            try:
+                if index < len(self.children):
+                    item = self.children[index]
+                    if isinstance(item, ListItem):
+                        self.scroll_to_widget(item, animate=False)
+            except Exception:
+                pass
+    
+    def watch_highlighted(self, highlighted: int | None) -> None:
+        """Watch for highlighted changes (arrow keys) and auto-show file diff."""
+        # Update highlighting
+        self._update_highlighting(highlighted)
+        
+        # Arrow keys update highlighted, update patch
+        if highlighted is not None and 0 <= highlighted < len(self._files):
+            file_status = self._files[highlighted]
+            file_path = file_status.path
+            
+            # For StagedPane, all files are staged
+            staged = True
+            untracked = file_status.status == "untracked"
+            
+            # Get app instance and show file diff
+            app = self.app
+            if app and hasattr(app, 'file_actions'):
+                # Switch to patch view
+                if hasattr(app, '_view_mode'):
+                    app._view_mode = "patch"
+                if hasattr(app, 'patch_pane') and hasattr(app, 'log_pane'):
+                    app.patch_pane.styles.display = "block"
+                    app.log_pane.styles.display = "none"
+                
+                # Show file diff
+                app.file_actions.show_file_diff(file_path, staged=staged, untracked=untracked)
+            
+            # Scroll to highlighted item to ensure it's visible
+            try:
+                if highlighted < len(self.children):
+                    item = self.children[highlighted]
+                    if isinstance(item, ListItem):
+                        self.scroll_to_widget(item, animate=False)
+            except Exception:
+                pass
+    
+    def _update_highlighting(self, index: int | None) -> None:
+        """Update visual highlighting by adding/removing classes."""
+        # Remove highlight from previous item
+        if self._last_highlighted is not None and self._last_highlighted < len(self.children):
+            try:
+                item = self.children[self._last_highlighted]
+                if isinstance(item, ListItem):
+                    item.remove_class("highlighted-file")
+            except:
+                pass
+        
+        # Add highlight to current item
+        if index is not None and index < len(self.children):
+            try:
+                item = self.children[index]
+                if isinstance(item, ListItem):
+                    item.add_class("highlighted-file")
+                    self._last_highlighted = index
+            except:
+                pass
+
 
 
 
@@ -350,6 +422,7 @@ class ChangesPane(ListView):
         self.border_title = "Changes"
         self.show_cursor = False
         self._files: list[FileStatus] = []  # Store files for access by index
+        self._last_highlighted: int | None = None  # Track highlighted changes
     
     def update_files(self, files: list[FileStatus]) -> None:
         """Update the unstaged files list."""
@@ -367,6 +440,7 @@ class ChangesPane(ListView):
         
         # Store filtered files for access by index
         self._files = unstaged_files
+        self._last_highlighted = None  # Reset highlighting when files are updated
         
         if not unstaged_files:
             from rich.text import Text
@@ -443,12 +517,15 @@ class ChangesPane(ListView):
     
     def watch_index(self, index: int | None) -> None:
         """Watch for index changes and auto-show file diff."""
+        # Update highlighting for mouse clicks
+        self._update_highlighting(index)
+        
         if index is not None and 0 <= index < len(self._files):
             file_status = self._files[index]
             file_path = file_status.path
             
-            # Determine if file is staged and untracked
-            staged = file_status.staged
+            # For ChangesPane, files are unstaged (show unstaged diff by default)
+            staged = False
             untracked = file_status.status == "untracked"
             
             # Get app instance and show file diff
@@ -463,8 +540,72 @@ class ChangesPane(ListView):
                 
                 # Show file diff
                 app.file_actions.show_file_diff(file_path, staged=staged, untracked=untracked)
-
-
+            
+            # Scroll to selected item to ensure it's visible
+            try:
+                if index < len(self.children):
+                    item = self.children[index]
+                    if isinstance(item, ListItem):
+                        self.scroll_to_widget(item, animate=False)
+            except Exception:
+                pass
+    
+    def watch_highlighted(self, highlighted: int | None) -> None:
+        """Watch for highlighted changes (arrow keys) and auto-show file diff."""
+        # Update highlighting
+        self._update_highlighting(highlighted)
+        
+        # Arrow keys update highlighted, update patch
+        if highlighted is not None and 0 <= highlighted < len(self._files):
+            file_status = self._files[highlighted]
+            file_path = file_status.path
+            
+            # For ChangesPane, files are unstaged (show unstaged diff by default)
+            staged = False
+            untracked = file_status.status == "untracked"
+            
+            # Get app instance and show file diff
+            app = self.app
+            if app and hasattr(app, 'file_actions'):
+                # Switch to patch view
+                if hasattr(app, '_view_mode'):
+                    app._view_mode = "patch"
+                if hasattr(app, 'patch_pane') and hasattr(app, 'log_pane'):
+                    app.patch_pane.styles.display = "block"
+                    app.log_pane.styles.display = "none"
+                
+                # Show file diff
+                app.file_actions.show_file_diff(file_path, staged=staged, untracked=untracked)
+            
+            # Scroll to highlighted item to ensure it's visible
+            try:
+                if highlighted < len(self.children):
+                    item = self.children[highlighted]
+                    if isinstance(item, ListItem):
+                        self.scroll_to_widget(item, animate=False)
+            except Exception:
+                pass
+    
+    def _update_highlighting(self, index: int | None) -> None:
+        """Update visual highlighting by adding/removing classes."""
+        # Remove highlight from previous item
+        if self._last_highlighted is not None and self._last_highlighted < len(self.children):
+            try:
+                item = self.children[self._last_highlighted]
+                if isinstance(item, ListItem):
+                    item.remove_class("highlighted-file")
+            except:
+                pass
+        
+        # Add highlight to current item
+        if index is not None and index < len(self.children):
+            try:
+                item = self.children[index]
+                if isinstance(item, ListItem):
+                    item.add_class("highlighted-file")
+                    self._last_highlighted = index
+            except:
+                pass
 
 
 # BranchesPane
@@ -488,6 +629,7 @@ class BranchesPane(ListView):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.border_title = "Local branches"
+        self._last_highlighted: int | None = None  # Track highlighted changes
     
     def action_new_branch(self) -> None:
         """Delegate new_branch action to the app.
@@ -521,6 +663,55 @@ class BranchesPane(ListView):
         app = self.app
         if app and hasattr(app, 'action_rename_branch'):
             app.action_rename_branch()
+    
+    def watch_highlighted(self, highlighted: int | None) -> None:
+        """Watch for highlighted changes (arrow keys) to update visual highlighting."""
+        # Update highlighting
+        self._update_highlighting(highlighted)
+        
+        # Scroll to highlighted item to ensure it's visible
+        try:
+            if highlighted is not None and highlighted < len(self.children):
+                item = self.children[highlighted]
+                if isinstance(item, ListItem):
+                    self.scroll_to_widget(item, animate=False)
+        except Exception:
+            pass
+    
+    def watch_index(self, index: int | None) -> None:
+        """Watch for index changes to update visual highlighting."""
+        # Update highlighting for mouse clicks
+        self._update_highlighting(index)
+        
+        # Scroll to selected item to ensure it's visible
+        try:
+            if index is not None and index < len(self.children):
+                item = self.children[index]
+                if isinstance(item, ListItem):
+                    self.scroll_to_widget(item, animate=False)
+        except Exception:
+            pass
+    
+    def _update_highlighting(self, index: int | None) -> None:
+        """Update visual highlighting by adding/removing classes."""
+        # Remove highlight from previous item
+        if self._last_highlighted is not None and self._last_highlighted < len(self.children):
+            try:
+                item = self.children[self._last_highlighted]
+                if isinstance(item, ListItem):
+                    item.remove_class("highlighted-branch")
+            except:
+                pass
+        
+        # Add highlight to current item
+        if index is not None and index < len(self.children):
+            try:
+                item = self.children[index]
+                if isinstance(item, ListItem):
+                    item.add_class("highlighted-branch")
+                    self._last_highlighted = index
+            except:
+                pass
 
     def action_select(self) -> None:
         """Handle select action (Enter/Space) for branch selection.
@@ -543,6 +734,7 @@ class BranchesPane(ListView):
                 'behind', 'ahead', 'synced', 'upstream'
         """
         self.clear()
+        self._last_highlighted = None  # Reset highlighting when branches are updated
         if sync_status is None:
             sync_status = {}
         
@@ -858,6 +1050,15 @@ class CommitsPane(ListView):
         """Watch for index changes and auto-update patch panel."""
         self._update_patch_for_index(index)
         self._update_highlighting(index)
+        
+        # Scroll to selected item to ensure it's visible
+        try:
+            if index is not None and index < len(self.children):
+                item = self.children[index]
+                if isinstance(item, ListItem):
+                    self.scroll_to_widget(item, animate=False)
+        except Exception:
+            pass
     
     def watch_highlighted(self, highlighted: int | None) -> None:
         """Watch for highlighted changes (arrow keys) and auto-update patch panel."""
@@ -865,6 +1066,14 @@ class CommitsPane(ListView):
         if highlighted is not None:
             self._update_patch_for_index(highlighted)
             self._update_highlighting(highlighted)
+            # Scroll to highlighted item to ensure it's visible
+            try:
+                if highlighted < len(self.children):
+                    item = self.children[highlighted]
+                    if isinstance(item, ListItem):
+                        self.scroll_to_widget(item, animate=False)
+            except Exception:
+                pass
     
     def _update_highlighting(self, index: int | None) -> None:
         """Update visual highlighting by adding/removing classes."""
@@ -896,6 +1105,7 @@ class CommitsPane(ListView):
     
     def set_commits(self, commits: list[CommitInfo]) -> None:
         self.clear()
+        self._last_highlighted = None  # Reset highlighting when commits are updated
         self._last_highlighted = None  # Reset highlighting tracker
         
         # Store commit SHAs and commit info for in-place updates
@@ -1217,6 +1427,15 @@ class StashPane(ListView):
         """Watch for index changes and auto-update patch panel."""
         self._update_patch_for_index(index)
         self._update_highlighting(index)
+        
+        # Scroll to selected item to ensure it's visible
+        try:
+            if index is not None and index < len(self.children):
+                item = self.children[index]
+                if isinstance(item, ListItem):
+                    self.scroll_to_widget(item, animate=False)
+        except Exception:
+            pass
     
     def watch_highlighted(self, highlighted: int | None) -> None:
         """Watch for highlighted changes (arrow keys) and auto-update patch panel."""
@@ -1224,6 +1443,14 @@ class StashPane(ListView):
         if highlighted is not None:
             self._update_patch_for_index(highlighted)
             self._update_highlighting(highlighted)
+            # Scroll to highlighted item to ensure it's visible
+            try:
+                if highlighted < len(self.children):
+                    item = self.children[highlighted]
+                    if isinstance(item, ListItem):
+                        self.scroll_to_widget(item, animate=False)
+            except Exception:
+                pass
     
     def _update_highlighting(self, index: int | None) -> None:
         """Update visual highlighting by adding/removing classes."""

--- a/src/pygitzen/ui/panes.py
+++ b/src/pygitzen/ui/panes.py
@@ -363,7 +363,7 @@ class StagedPane(ListView):
     def action_discard_file(self) -> None:
         """Discard changes for the selected file.
         
-        Shows confirmation dialog before discarding.
+        Shows options dialog with discard choices.
         """
         # Get selected file index
         selected_index = self.index
@@ -374,20 +374,69 @@ class StagedPane(ListView):
         file_status = self._files[selected_index]
         file_path = file_status.path
         
-        # For StagedPane, files are staged
-        change_type = "staged"
-        
-        # Get app instance and show confirmation dialog
+        # Get app instance and show options dialog
         app = self.app
         if app:
-            from ..ui.dialogs import DiscardFileDialog
-            dialog = DiscardFileDialog(file_path, change_type=change_type, title="Discard Staged Changes")
+            from ..ui.dialogs import DiscardOptionsDialog, DiscardAllConfirmDialog, DiscardFileDialog
+            # Check if there are both staged and unstaged files
+            files = app.git.get_file_status()
+            has_staged = any(f.staged for f in files)
+            has_unstaged = any(f.unstaged or f.status == "untracked" for f in files)
+            dialog = DiscardOptionsDialog(file_path, pane_type="staged", has_staged=has_staged, has_unstaged=has_unstaged)
             
-            def handle_discard(confirmed: bool) -> None:
-                if confirmed and hasattr(app, 'file_actions'):
-                    app.file_actions.discard_file(file_path, staged=True, untracked=False)
+            def handle_option(option: str | None) -> None:
+                if not option or not hasattr(app, 'file_actions'):
+                    return
+                
+                if option == "file_staged":
+                    # Single file, staged only - use existing simple confirmation
+                    confirm_dialog = DiscardFileDialog(file_path, change_type="staged", title="Discard Staged Changes")
+                    def handle_confirm(confirmed: bool) -> None:
+                        if confirmed:
+                            app.file_actions.discard_file(file_path, staged=True, untracked=False)
+                    app.push_screen(confirm_dialog, handle_confirm)
+                
+                elif option == "all_staged":
+                    # All staged files - show confirmation with file list
+                    files = app.git.get_file_status()
+                    staged_files = [f for f in files if f.staged]
+                    if not staged_files:
+                        app.notify("No staged changes to discard", severity="warning", timeout=2.0)
+                        return
+                    
+                    file_paths = [f.path for f in staged_files]
+                    confirm_dialog = DiscardAllConfirmDialog(
+                        title="Discard All Staged Changes",
+                        message=f"Are you sure you want to discard staged changes for {len(staged_files)} file(s)?",
+                        file_list=file_paths,
+                        file_count=len(staged_files)
+                    )
+                    def handle_confirm(confirmed: bool) -> None:
+                        if confirmed:
+                            app.file_actions.discard_all_staged_changes()
+                    app.push_screen(confirm_dialog, handle_confirm)
+                
+                elif option == "all_both":
+                    # All staged and unstaged files - show confirmation with file list
+                    files = app.git.get_file_status()
+                    all_changed_files = [f for f in files if f.staged or f.unstaged or f.status in ["modified", "untracked", "deleted"]]
+                    if not all_changed_files:
+                        app.notify("No changes to discard", severity="warning", timeout=2.0)
+                        return
+                    
+                    file_paths = [f.path for f in all_changed_files]
+                    confirm_dialog = DiscardAllConfirmDialog(
+                        title="Discard All Changes",
+                        message=f"Are you sure you want to discard ALL changes (staged and unstaged) for {len(all_changed_files)} file(s)?",
+                        file_list=file_paths,
+                        file_count=len(all_changed_files)
+                    )
+                    def handle_confirm(confirmed: bool) -> None:
+                        if confirmed:
+                            app.file_actions.discard_all_changes()
+                    app.push_screen(confirm_dialog, handle_confirm)
             
-            app.push_screen(dialog, handle_discard)
+            app.push_screen(dialog, handle_option)
     
     def watch_index(self, index: int | None) -> None:
         """Watch for index changes and auto-show file diff."""
@@ -640,7 +689,7 @@ class ChangesPane(ListView):
     def action_discard_file(self) -> None:
         """Discard changes for the selected file.
         
-        Shows confirmation dialog before discarding.
+        Shows options dialog with discard choices.
         """
         # Get selected file index
         selected_index = self.index
@@ -651,21 +700,71 @@ class ChangesPane(ListView):
         file_status = self._files[selected_index]
         file_path = file_status.path
         
-        # For ChangesPane, files are unstaged or untracked
-        change_type = "untracked" if file_status.status == "untracked" else "unstaged"
-        
-        # Get app instance and show confirmation dialog
+        # Get app instance and show options dialog
         app = self.app
         if app:
-            from ..ui.dialogs import DiscardFileDialog
-            dialog = DiscardFileDialog(file_path, change_type=change_type, title="Discard Changes")
+            from ..ui.dialogs import DiscardOptionsDialog, DiscardAllConfirmDialog, DiscardFileDialog
+            # Check if there are both staged and unstaged files
+            files = app.git.get_file_status()
+            has_staged = any(f.staged for f in files)
+            has_unstaged = any(f.unstaged or f.status == "untracked" for f in files)
+            dialog = DiscardOptionsDialog(file_path, pane_type="changes", has_staged=has_staged, has_unstaged=has_unstaged)
             
-            def handle_discard(confirmed: bool) -> None:
-                if confirmed and hasattr(app, 'file_actions'):
+            def handle_option(option: str | None) -> None:
+                if not option or not hasattr(app, 'file_actions'):
+                    return
+                
+                if option == "file_unstaged":
+                    # Single file, unstaged only - use existing simple confirmation
                     untracked = file_status.status == "untracked"
-                    app.file_actions.discard_file(file_path, staged=False, untracked=untracked)
+                    change_type = "untracked" if untracked else "unstaged"
+                    confirm_dialog = DiscardFileDialog(file_path, change_type=change_type, title="Discard Changes")
+                    def handle_confirm(confirmed: bool) -> None:
+                        if confirmed:
+                            app.file_actions.discard_file(file_path, staged=False, untracked=untracked)
+                    app.push_screen(confirm_dialog, handle_confirm)
+                
+                elif option == "all_unstaged":
+                    # All unstaged files - show confirmation with file list
+                    files = app.git.get_file_status()
+                    unstaged_files = [f for f in files if f.unstaged or (not f.staged and f.status in ["modified", "untracked", "deleted"])]
+                    if not unstaged_files:
+                        app.notify("No unstaged changes to discard", severity="warning", timeout=2.0)
+                        return
+                    
+                    file_paths = [f.path for f in unstaged_files]
+                    confirm_dialog = DiscardAllConfirmDialog(
+                        title="Discard All Unstaged Changes",
+                        message=f"Are you sure you want to discard unstaged changes for {len(unstaged_files)} file(s)?",
+                        file_list=file_paths,
+                        file_count=len(unstaged_files)
+                    )
+                    def handle_confirm(confirmed: bool) -> None:
+                        if confirmed:
+                            app.file_actions.discard_all_unstaged_changes()
+                    app.push_screen(confirm_dialog, handle_confirm)
+                
+                elif option == "all_both":
+                    # All staged and unstaged files - show confirmation with file list
+                    files = app.git.get_file_status()
+                    all_changed_files = [f for f in files if f.staged or f.unstaged or f.status in ["modified", "untracked", "deleted"]]
+                    if not all_changed_files:
+                        app.notify("No changes to discard", severity="warning", timeout=2.0)
+                        return
+                    
+                    file_paths = [f.path for f in all_changed_files]
+                    confirm_dialog = DiscardAllConfirmDialog(
+                        title="Discard All Changes",
+                        message=f"Are you sure you want to discard ALL changes (staged and unstaged) for {len(all_changed_files)} file(s)?",
+                        file_list=file_paths,
+                        file_count=len(all_changed_files)
+                    )
+                    def handle_confirm(confirmed: bool) -> None:
+                        if confirmed:
+                            app.file_actions.discard_all_changes()
+                    app.push_screen(confirm_dialog, handle_confirm)
             
-            app.push_screen(dialog, handle_discard)
+            app.push_screen(dialog, handle_option)
     
     def watch_index(self, index: int | None) -> None:
         """Watch for index changes and auto-show file diff."""

--- a/src/pygitzen/ui/panes.py
+++ b/src/pygitzen/ui/panes.py
@@ -511,6 +511,18 @@ class StagedPane(ListView):
     
     def _update_highlighting(self, index: int | None) -> None:
         """Update visual highlighting by adding/removing classes."""
+        # Only show highlighting when pane has focus
+        if not self.has_focus:
+            # Remove all highlighting when pane loses focus
+            if self._last_highlighted is not None and self._last_highlighted < len(self.children):
+                try:
+                    item = self.children[self._last_highlighted]
+                    if isinstance(item, ListItem):
+                        item.remove_class("highlighted-file")
+                except:
+                    pass
+            return
+        
         # Remove highlight from previous item
         if self._last_highlighted is not None and self._last_highlighted < len(self.children):
             try:
@@ -529,6 +541,61 @@ class StagedPane(ListView):
                     self._last_highlighted = index
             except:
                 pass
+    
+    def on_focus(self) -> None:
+        """Handle pane gaining focus - restore highlighting and auto-show file diff."""
+        # Restore highlighting if we have a highlighted item
+        # Prefer _last_highlighted over highlighted to preserve selection across focus changes
+        current_index = self._last_highlighted if self._last_highlighted is not None else (self.highlighted if hasattr(self, 'highlighted') and self.highlighted is not None else None)
+        
+        # If no item is highlighted and pane has items, highlight the first one
+        if current_index is None and len(self._files) > 0:
+            current_index = 0
+        
+        # Set both highlighted and index to ensure ListView knows which item is selected
+        if current_index is not None:
+            self.highlighted = current_index
+            self.index = current_index
+            # Update _last_highlighted to preserve selection
+            self._last_highlighted = current_index
+            # Use set_timer with minimal delay to ensure highlighting happens after focus is fully established
+            try:
+                self.set_timer(0.01, lambda: self._update_highlighting(current_index))
+            except:
+                # Fallback: call directly if timer not available
+                self._update_highlighting(current_index)
+            
+            # Auto-show file diff for the highlighted item
+            if 0 <= current_index < len(self._files):
+                file_status = self._files[current_index]
+                file_path = file_status.path
+                staged = True
+                untracked = file_status.status == "untracked"
+                
+                app = self.app
+                if app and hasattr(app, 'file_actions'):
+                    # Switch to patch view
+                    if hasattr(app, '_view_mode'):
+                        app._view_mode = "patch"
+                    if hasattr(app, 'patch_pane') and hasattr(app, 'log_pane'):
+                        app.patch_pane.styles.display = "block"
+                        app.log_pane.styles.display = "none"
+                    
+                    # Show file diff
+                    app.file_actions.show_file_diff(file_path, staged=staged, untracked=untracked)
+    
+    def on_blur(self) -> None:
+        """Handle pane losing focus - remove highlighting (but preserve _last_highlighted)."""
+        # Only remove visual highlighting, don't reset _last_highlighted
+        # This preserves the selection so it can be restored when focus returns
+        if self._last_highlighted is not None and self._last_highlighted < len(self.children):
+            try:
+                item = self.children[self._last_highlighted]
+                if isinstance(item, ListItem):
+                    item.remove_class("highlighted-file")
+            except:
+                pass
+        # Don't reset _last_highlighted - we want to preserve it for when focus returns
 
 
 
@@ -839,6 +906,18 @@ class ChangesPane(ListView):
     
     def _update_highlighting(self, index: int | None) -> None:
         """Update visual highlighting by adding/removing classes."""
+        # Only show highlighting when pane has focus
+        if not self.has_focus:
+            # Remove all highlighting when pane loses focus
+            if self._last_highlighted is not None and self._last_highlighted < len(self.children):
+                try:
+                    item = self.children[self._last_highlighted]
+                    if isinstance(item, ListItem):
+                        item.remove_class("highlighted-file")
+                except:
+                    pass
+            return
+        
         # Remove highlight from previous item
         if self._last_highlighted is not None and self._last_highlighted < len(self.children):
             try:
@@ -857,6 +936,63 @@ class ChangesPane(ListView):
                     self._last_highlighted = index
             except:
                 pass
+    
+    def on_focus(self) -> None:
+        """Handle pane gaining focus - restore highlighting and auto-show file diff."""
+        # Restore highlighting if we have a highlighted item
+        # Prefer _last_highlighted over highlighted to preserve selection across focus changes
+        current_index = self._last_highlighted if self._last_highlighted is not None else (self.highlighted if hasattr(self, 'highlighted') and self.highlighted is not None else None)
+        
+        # If no item is highlighted and pane has items, highlight the first one
+        if current_index is None and len(self._files) > 0:
+            current_index = 0
+        
+        # Set both highlighted and index to ensure ListView knows which item is selected
+        if current_index is not None:
+            self.highlighted = current_index
+            self.index = current_index
+            # Update _last_highlighted to preserve selection
+            self._last_highlighted = current_index
+            # Use set_timer with minimal delay to ensure highlighting happens after focus is fully established
+            try:
+                self.set_timer(0.01, lambda: self._update_highlighting(current_index))
+            except:
+                # Fallback: call directly if timer not available
+                self._update_highlighting(current_index)
+            
+            # Auto-show file diff for the highlighted item
+            if 0 <= current_index < len(self._files):
+                file_status = self._files[current_index]
+                file_path = file_status.path
+                # For ChangesPane, files are unstaged (unless they have both)
+                staged = file_status.staged
+                unstaged = file_status.unstaged or file_status.status in ["modified", "untracked", "deleted"]
+                untracked = file_status.status == "untracked"
+                
+                app = self.app
+                if app and hasattr(app, 'file_actions'):
+                    # Switch to patch view
+                    if hasattr(app, '_view_mode'):
+                        app._view_mode = "patch"
+                    if hasattr(app, 'patch_pane') and hasattr(app, 'log_pane'):
+                        app.patch_pane.styles.display = "block"
+                        app.log_pane.styles.display = "none"
+                    
+                    # Show file diff (unstaged changes)
+                    app.file_actions.show_file_diff(file_path, staged=False, untracked=untracked)
+    
+    def on_blur(self) -> None:
+        """Handle pane losing focus - remove highlighting (but preserve _last_highlighted)."""
+        # Only remove visual highlighting, don't reset _last_highlighted
+        # This preserves the selection so it can be restored when focus returns
+        if self._last_highlighted is not None and self._last_highlighted < len(self.children):
+            try:
+                item = self.children[self._last_highlighted]
+                if isinstance(item, ListItem):
+                    item.remove_class("highlighted-file")
+            except:
+                pass
+        # Don't reset _last_highlighted - we want to preserve it for when focus returns
 
 
 # BranchesPane
@@ -917,9 +1053,18 @@ class BranchesPane(ListView):
             app.action_rename_branch()
     
     def watch_highlighted(self, highlighted: int | None) -> None:
-        """Watch for highlighted changes (arrow keys) to update visual highlighting."""
+        """Watch for highlighted changes (arrow keys) to update visual highlighting and show branch logs."""
         # Update highlighting
         self._update_highlighting(highlighted)
+        
+        # Auto-show branch logs when branch is highlighted
+        if highlighted is not None and hasattr(self, '_branches') and 0 <= highlighted < len(self._branches):
+            branch = self._branches[highlighted]
+            app = self.app
+            if app and hasattr(app, 'load_commits'):
+                # Load commits for the highlighted branch
+                app.active_branch = branch.name
+                app.load_commits(branch.name)
         
         # Scroll to highlighted item to ensure it's visible
         try:
@@ -929,6 +1074,55 @@ class BranchesPane(ListView):
                     self.scroll_to_widget(item, animate=False)
         except Exception:
             pass
+    
+    def on_focus(self) -> None:
+        """Handle pane gaining focus - restore highlighting and auto-show branch logs."""
+        # Restore highlighting if we have a highlighted item
+        # Prefer _last_highlighted over highlighted to preserve selection across focus changes
+        current_index = self._last_highlighted if self._last_highlighted is not None else (self.highlighted if hasattr(self, 'highlighted') and self.highlighted is not None else None)
+        
+        # If no item is highlighted and pane has items, highlight the first one
+        if current_index is None and hasattr(self, '_branches') and len(self._branches) > 0:
+            current_index = 0
+        
+        # Set both highlighted and index to ensure ListView knows which item is selected
+        if current_index is not None:
+            self.highlighted = current_index
+            self.index = current_index
+            # Update _last_highlighted to preserve selection
+            self._last_highlighted = current_index
+            # Use set_timer with minimal delay to ensure highlighting happens after focus is fully established
+            try:
+                self.set_timer(0.01, lambda: self._update_highlighting(current_index))
+            except:
+                # Fallback: call directly if timer not available
+                self._update_highlighting(current_index)
+            
+            # Auto-show branch logs for the highlighted branch
+            if hasattr(self, '_branches') and 0 <= current_index < len(self._branches):
+                branch = self._branches[current_index]
+                app = self.app
+                if app and hasattr(app, 'load_commits') and hasattr(app, 'load_commits_for_log'):
+                    # Load commits for the highlighted branch
+                    app.active_branch = branch.name
+                    # Switch to log view (not patch view) when branches pane is focused
+                    if hasattr(app, '_view_mode'):
+                        app._view_mode = "log"
+                    if hasattr(app, 'patch_pane') and hasattr(app, 'log_pane'):
+                        app.patch_pane.styles.display = "none"
+                        app.log_pane.styles.display = "block"
+                    # Load commits for log view (shows git log --graph)
+                    app.load_commits_for_log(branch.name)
+    
+    def on_blur(self) -> None:
+        """Handle pane losing focus - remove highlighting."""
+        if self._last_highlighted is not None and self._last_highlighted < len(self.children):
+            try:
+                item = self.children[self._last_highlighted]
+                if isinstance(item, ListItem):
+                    item.remove_class("highlighted-branch")
+            except:
+                pass
     
     def watch_index(self, index: int | None) -> None:
         """Watch for index changes to update visual highlighting."""
@@ -1017,6 +1211,9 @@ class BranchesPane(ListView):
         preserve_index = current_index if current_index is not None else current_highlighted
         
         self.clear()
+        
+        # Store branches for access by index
+        self._branches = branches
         
         # Restore highlighting after update if we had a selection
         if preserve_index is not None:
@@ -1140,6 +1337,18 @@ class RemotesPane(ListView):
     
     def _update_highlighting(self, index: int | None) -> None:
         """Update visual highlighting by adding/removing classes."""
+        # Only show highlighting when pane has focus
+        if not self.has_focus:
+            # Remove all highlighting when pane loses focus
+            if self._last_highlighted is not None and self._last_highlighted < len(self.children):
+                try:
+                    item = self.children[self._last_highlighted]
+                    if isinstance(item, ListItem):
+                        item.remove_class("highlighted-remote")
+                except:
+                    pass
+            return
+        
         # Remove highlight from previous item
         if self._last_highlighted is not None and self._last_highlighted < len(self.children):
             try:
@@ -1156,6 +1365,30 @@ class RemotesPane(ListView):
                 if isinstance(item, ListItem):
                     item.add_class("highlighted-remote")
                     self._last_highlighted = index
+            except:
+                pass
+    
+    def on_focus(self) -> None:
+        """Handle pane gaining focus - restore highlighting."""
+        # Restore highlighting if we have a highlighted item
+        current_index = self.highlighted if hasattr(self, 'highlighted') and self.highlighted is not None else self._last_highlighted
+        
+        # If no item is highlighted and pane has items, highlight the first one
+        if current_index is None and len(self._remotes) > 0:
+            current_index = 0
+            self.highlighted = 0
+        
+        # Update highlighting
+        if current_index is not None:
+            self._update_highlighting(current_index)
+    
+    def on_blur(self) -> None:
+        """Handle pane losing focus - remove highlighting."""
+        if self._last_highlighted is not None and self._last_highlighted < len(self.children):
+            try:
+                item = self.children[self._last_highlighted]
+                if isinstance(item, ListItem):
+                    item.remove_class("highlighted-remote")
             except:
                 pass
     
@@ -1250,6 +1483,18 @@ class TagsPane(ListView):
     
     def _update_highlighting(self, index: int | None) -> None:
         """Update visual highlighting by adding/removing classes."""
+        # Only show highlighting when pane has focus
+        if not self.has_focus:
+            # Remove all highlighting when pane loses focus
+            if self._last_highlighted is not None and self._last_highlighted < len(self.children):
+                try:
+                    item = self.children[self._last_highlighted]
+                    if isinstance(item, ListItem):
+                        item.remove_class("highlighted-tag")
+                except:
+                    pass
+            return
+        
         # Remove highlight from previous item
         if self._last_highlighted is not None and self._last_highlighted < len(self.children):
             try:
@@ -1266,6 +1511,30 @@ class TagsPane(ListView):
                 if isinstance(item, ListItem):
                     item.add_class("highlighted-tag")
                     self._last_highlighted = index
+            except:
+                pass
+    
+    def on_focus(self) -> None:
+        """Handle pane gaining focus - restore highlighting."""
+        # Restore highlighting if we have a highlighted item
+        current_index = self.highlighted if hasattr(self, 'highlighted') and self.highlighted is not None else self._last_highlighted
+        
+        # If no item is highlighted and pane has items, highlight the first one
+        if current_index is None and len(self._tags) > 0:
+            current_index = 0
+            self.highlighted = 0
+        
+        # Update highlighting
+        if current_index is not None:
+            self._update_highlighting(current_index)
+    
+    def on_blur(self) -> None:
+        """Handle pane losing focus - remove highlighting."""
+        if self._last_highlighted is not None and self._last_highlighted < len(self.children):
+            try:
+                item = self.children[self._last_highlighted]
+                if isinstance(item, ListItem):
+                    item.remove_class("highlighted-tag")
             except:
                 pass
     
@@ -1444,6 +1713,18 @@ class CommitsPane(ListView):
     
     def _update_highlighting(self, index: int | None) -> None:
         """Update visual highlighting by adding/removing classes."""
+        # Only show highlighting when pane has focus
+        if not self.has_focus:
+            # Remove all highlighting when pane loses focus
+            if self._last_highlighted is not None and self._last_highlighted < len(self.children):
+                try:
+                    item = self.children[self._last_highlighted]
+                    if isinstance(item, ListItem):
+                        item.remove_class("highlighted-commit")
+                except:
+                    pass
+            return
+        
         # Remove highlight from previous item
         if self._last_highlighted is not None and self._last_highlighted < len(self.children):
             try:
@@ -1462,6 +1743,64 @@ class CommitsPane(ListView):
                     self._last_highlighted = index
             except:
                 pass
+    
+    def on_focus(self) -> None:
+        """Handle pane gaining focus - restore highlighting and auto-show commit patch."""
+        # Restore highlighting if we have a highlighted item
+        # Prefer _last_highlighted over highlighted to preserve selection across focus changes
+        current_index = self._last_highlighted if self._last_highlighted is not None else (self.highlighted if hasattr(self, 'highlighted') and self.highlighted is not None else None)
+        
+        # Get commits from parent app
+        commits = []
+        if self._parent_app and hasattr(self._parent_app, 'commits'):
+            commits = self._parent_app.commits
+        
+        # If no item is highlighted and pane has items, highlight the first one
+        if current_index is None and len(commits) > 0:
+            current_index = 0
+        
+        # Set both highlighted and index to ensure ListView knows which item is selected
+        if current_index is not None:
+            self.highlighted = current_index
+            self.index = current_index
+            # Update _last_highlighted to preserve selection
+            self._last_highlighted = current_index
+            # Use set_timer with minimal delay to ensure highlighting happens after focus is fully established
+            try:
+                self.set_timer(0.01, lambda: self._update_highlighting(current_index))
+            except:
+                # Fallback: call directly if timer not available
+                self._update_highlighting(current_index)
+            
+            # Auto-show commit patch for the highlighted item
+            if 0 <= current_index < len(commits):
+                # Explicitly show commit diff (similar to how changes pane shows file diff)
+                # This ensures the patch is shown even if _last_index is the same
+                if self._parent_app:
+                    # Switch to patch view
+                    if hasattr(self._parent_app, '_view_mode'):
+                        self._parent_app._view_mode = "patch"
+                    if hasattr(self._parent_app, 'patch_pane') and hasattr(self._parent_app, 'log_pane'):
+                        self._parent_app.patch_pane.styles.display = "block"
+                        self._parent_app.log_pane.styles.display = "none"
+                    # Show commit diff directly
+                    self._parent_app.selected_commit_index = current_index
+                    self._parent_app.show_commit_diff(current_index)
+                    # Update _last_index to track that we've shown this commit
+                    self._last_index = current_index
+    
+    def on_blur(self) -> None:
+        """Handle pane losing focus - remove highlighting (but preserve _last_highlighted)."""
+        # Only remove visual highlighting, don't reset _last_highlighted
+        # This preserves the selection so it can be restored when focus returns
+        if self._last_highlighted is not None and self._last_highlighted < len(self.children):
+            try:
+                item = self.children[self._last_highlighted]
+                if isinstance(item, ListItem):
+                    item.remove_class("highlighted-commit")
+            except:
+                pass
+        # Don't reset _last_highlighted - we want to preserve it for when focus returns
     
     def _update_patch_for_index(self, index: int | None) -> None:
         """Update patch panel for the given index."""
@@ -1823,6 +2162,18 @@ class StashPane(ListView):
     
     def _update_highlighting(self, index: int | None) -> None:
         """Update visual highlighting by adding/removing classes."""
+        # Only show highlighting when pane has focus
+        if not self.has_focus:
+            # Remove all highlighting when pane loses focus
+            if self._last_highlighted is not None and self._last_highlighted < len(self.children):
+                try:
+                    item = self.children[self._last_highlighted]
+                    if isinstance(item, ListItem):
+                        item.remove_class("highlighted-stash")
+                except:
+                    pass
+            return
+        
         # Remove highlight from previous item
         if self._last_highlighted is not None and self._last_highlighted < len(self.children):
             try:
@@ -1841,6 +2192,46 @@ class StashPane(ListView):
                     self._last_highlighted = index
             except:
                 pass
+    
+    def on_focus(self) -> None:
+        """Handle pane gaining focus - restore highlighting and auto-show stash diff."""
+        # Restore highlighting if we have a highlighted item
+        # Prefer _last_highlighted over highlighted to preserve selection across focus changes
+        current_index = self._last_highlighted if self._last_highlighted is not None else (self.highlighted if hasattr(self, 'highlighted') and self.highlighted is not None else None)
+        
+        # If no item is highlighted and pane has items, highlight the first one
+        if current_index is None and len(self._stashes) > 0:
+            current_index = 0
+        
+        # Set both highlighted and index to ensure ListView knows which item is selected
+        if current_index is not None:
+            self.highlighted = current_index
+            self.index = current_index
+            # Update _last_highlighted to preserve selection
+            self._last_highlighted = current_index
+            # Use set_timer with minimal delay to ensure highlighting happens after focus is fully established
+            try:
+                self.set_timer(0.01, lambda: self._update_highlighting(current_index))
+            except:
+                # Fallback: call directly if timer not available
+                self._update_highlighting(current_index)
+            
+            # Auto-show stash diff for the highlighted item
+            if 0 <= current_index < len(self._stashes):
+                self._update_patch_for_index(current_index)
+    
+    def on_blur(self) -> None:
+        """Handle pane losing focus - remove highlighting (but preserve _last_highlighted)."""
+        # Only remove visual highlighting, don't reset _last_highlighted
+        # This preserves the selection so it can be restored when focus returns
+        if self._last_highlighted is not None and self._last_highlighted < len(self.children):
+            try:
+                item = self.children[self._last_highlighted]
+                if isinstance(item, ListItem):
+                    item.remove_class("highlighted-stash")
+            except:
+                pass
+        # Don't reset _last_highlighted - we want to preserve it for when focus returns
     
     def _update_patch_for_index(self, index: int | None) -> None:
         """Update patch panel for the given index."""

--- a/src/pygitzen/ui/panes.py
+++ b/src/pygitzen/ui/panes.py
@@ -2218,7 +2218,19 @@ class StashPane(ListView):
             
             # Auto-show stash diff for the highlighted item
             if 0 <= current_index < len(self._stashes):
-                self._update_patch_for_index(current_index)
+                # Explicitly show stash diff (similar to how changes pane shows file diff)
+                # This ensures the diff is shown even if _last_index is the same
+                if self._parent_app:
+                    # Switch to patch view
+                    if hasattr(self._parent_app, '_view_mode'):
+                        self._parent_app._view_mode = "patch"
+                    if hasattr(self._parent_app, 'patch_pane') and hasattr(self._parent_app, 'log_pane'):
+                        self._parent_app.patch_pane.styles.display = "block"
+                        self._parent_app.log_pane.styles.display = "none"
+                    # Show stash diff directly
+                    self._parent_app.show_stash_diff(current_index)
+                    # Update _last_index to track that we've shown this stash
+                    self._last_index = current_index
     
     def on_blur(self) -> None:
         """Handle pane losing focus - remove highlighting (but preserve _last_highlighted)."""

--- a/src/pygitzen/ui/panes.py
+++ b/src/pygitzen/ui/panes.py
@@ -223,6 +223,7 @@ class StagedPane(ListView):
         self.show_cursor = False
         self._files: list[FileStatus] = []  # Store files for access by index
         self._last_highlighted: int | None = None  # Track highlighted changes
+        self._pending_highlight_index: int | None = None  # Store index to highlight after update
     
     def update_files(self, files: list[FileStatus]) -> None:
         """Update the staged files list."""
@@ -236,7 +237,27 @@ class StagedPane(ListView):
         
         # Store filtered files for access by index
         self._files = staged_files
-        self._last_highlighted = None  # Reset highlighting when files are updated
+        
+        # Restore highlight position if pending (after unstaging a file)
+        if self._pending_highlight_index is not None:
+            target_index = self._pending_highlight_index
+            # If target index is out of bounds, use the last item or 0
+            if target_index >= len(staged_files):
+                target_index = max(0, len(staged_files) - 1) if staged_files else None
+            if target_index is not None and target_index < len(staged_files):
+                # Set index and highlight after a brief delay to ensure UI is updated
+                def restore_highlight():
+                    self.index = target_index
+                    self._update_highlighting(target_index)
+                # Use call_later to ensure UI is ready
+                if hasattr(self.app, 'set_timer'):
+                    self.app.set_timer(0.1, restore_highlight)
+                else:
+                    # Fallback: set immediately
+                    restore_highlight()
+            self._pending_highlight_index = None
+        else:
+            self._last_highlighted = None  # Reset highlighting when files are updated
         
         if not staged_files:
             from rich.text import Text
@@ -282,6 +303,11 @@ class StagedPane(ListView):
         # Get the file to unstage
         file_status = self._files[selected_index]
         file_path = file_status.path
+        
+        # Store the current index to restore highlight after unstaging
+        # If we're at the last item, stay at the last item (which will be the previous one after unstaging)
+        # Otherwise, stay at the same index (which will be the next item after unstaging)
+        self._pending_highlight_index = selected_index
         
         # Get app instance and delegate to handler
         app = self.app

--- a/src/pygitzen/ui/panes.py
+++ b/src/pygitzen/ui/panes.py
@@ -2162,7 +2162,38 @@ class StashPane(ListView):
     
     def _update_highlighting(self, index: int | None) -> None:
         """Update visual highlighting by adding/removing classes."""
-        # Only show highlighting when pane has focus
+        # If index is being set (mouse click or keyboard), always show highlighting
+        # Mouse clicks should give focus, so we show highlighting even if focus check temporarily fails
+        if index is not None:
+            # If we have an index but no focus, try to get focus (mouse click should give focus)
+            if not self.has_focus:
+                try:
+                    self.focus()
+                except:
+                    pass
+            
+            # Always show highlighting when index is set (mouse click or keyboard navigation)
+            # Remove highlight from previous item
+            if self._last_highlighted is not None and self._last_highlighted < len(self.children):
+                try:
+                    item = self.children[self._last_highlighted]
+                    if isinstance(item, ListItem):
+                        item.remove_class("highlighted-stash")
+                except:
+                    pass
+            
+            # Add highlight to current item
+            if index < len(self.children):
+                try:
+                    item = self.children[index]
+                    if isinstance(item, ListItem):
+                        item.add_class("highlighted-stash")
+                        self._last_highlighted = index
+                except:
+                    pass
+            return
+        
+        # If index is None and no focus, remove highlighting
         if not self.has_focus:
             # Remove all highlighting when pane loses focus
             if self._last_highlighted is not None and self._last_highlighted < len(self.children):
@@ -2174,7 +2205,7 @@ class StashPane(ListView):
                     pass
             return
         
-        # Remove highlight from previous item
+        # Remove highlight from previous item (fallback for when index is None but pane has focus)
         if self._last_highlighted is not None and self._last_highlighted < len(self.children):
             try:
                 item = self.children[self._last_highlighted]
@@ -2182,25 +2213,25 @@ class StashPane(ListView):
                     item.remove_class("highlighted-stash")
             except:
                 pass
-        
-        # Add highlight to current item
-        if index is not None and index < len(self.children):
-            try:
-                item = self.children[index]
-                if isinstance(item, ListItem):
-                    item.add_class("highlighted-stash")
-                    self._last_highlighted = index
-            except:
-                pass
     
     def on_focus(self) -> None:
         """Handle pane gaining focus - restore highlighting and auto-show stash diff."""
         # Restore highlighting if we have a highlighted item
-        # Prefer _last_highlighted over highlighted to preserve selection across focus changes
-        current_index = self._last_highlighted if self._last_highlighted is not None else (self.highlighted if hasattr(self, 'highlighted') and self.highlighted is not None else None)
+        # Priority: self.index (set by Textual on click) > _last_highlighted > highlighted
+        # This ensures mouse clicks are respected even if on_focus() runs before watch_index()
+        current_index = None
+        if hasattr(self, 'index') and self.index is not None:
+            current_index = self.index
+        elif self._last_highlighted is not None:
+            current_index = self._last_highlighted
+        elif hasattr(self, 'highlighted') and self.highlighted is not None:
+            current_index = self.highlighted
+        
+        # Check if we're defaulting to 0 (no valid index found)
+        is_defaulting_to_zero = current_index is None and len(self._stashes) > 0
         
         # If no item is highlighted and pane has items, highlight the first one
-        if current_index is None and len(self._stashes) > 0:
+        if is_defaulting_to_zero:
             current_index = 0
         
         # Set both highlighted and index to ensure ListView knows which item is selected
@@ -2209,11 +2240,27 @@ class StashPane(ListView):
             self.index = current_index
             # Update _last_highlighted to preserve selection
             self._last_highlighted = current_index
-            # Use set_timer with minimal delay to ensure highlighting happens after focus is fully established
-            try:
-                self.set_timer(0.01, lambda: self._update_highlighting(current_index))
-            except:
-                # Fallback: call directly if timer not available
+            
+            # If we're defaulting to 0, delay highlighting slightly to let watch_index() run first
+            # This prevents the flash of item 0 when clicking on a different item
+            if is_defaulting_to_zero:
+                # Use a small delay to let watch_index() run first if user clicked an item
+                # Store the intended index to check if it's still valid when timer fires
+                intended_index = current_index
+                def delayed_highlight():
+                    # Only highlight if watch_index() hasn't already set a different index
+                    # Check if _last_highlighted matches our intended index (0)
+                    # If watch_index() ran, _last_highlighted will be different
+                    if self._last_highlighted == intended_index:
+                        self._update_highlighting(intended_index)
+                
+                try:
+                    self.set_timer(0.01, delayed_highlight)
+                except:
+                    # Fallback: call directly if timer not available
+                    self._update_highlighting(current_index)
+            else:
+                # Apply highlighting immediately for existing selections
                 self._update_highlighting(current_index)
             
             # Auto-show stash diff for the highlighted item

--- a/src/pygitzen/ui/panes.py
+++ b/src/pygitzen/ui/panes.py
@@ -1236,7 +1236,7 @@ class CommitsPane(ListView):
             self._update_highlighting(highlighted)
             # Scroll to highlighted item to ensure it's visible
             try:
-                if highlighted < len(self.children):
+                if highlighted is not None and 0 <= highlighted < len(self.children):
                     item = self.children[highlighted]
                     if isinstance(item, ListItem):
                         self.scroll_to_widget(item, animate=False)
@@ -1267,9 +1267,11 @@ class CommitsPane(ListView):
     def _update_patch_for_index(self, index: int | None) -> None:
         """Update patch panel for the given index."""
         if index is not None and index != self._last_index and self._parent_app:
-            self._last_index = index
-            self._parent_app.selected_commit_index = index
-            self._parent_app.show_commit_diff(index)
+            # Only show patch if pane has focus (user is navigating, not initial load)
+            if self.has_focus:
+                self._last_index = index
+                self._parent_app.selected_commit_index = index
+                self._parent_app.show_commit_diff(index)
     
     def set_commits(self, commits: list[CommitInfo]) -> None:
         self.clear()

--- a/src/pygitzen/ui/panes.py
+++ b/src/pygitzen/ui/panes.py
@@ -423,6 +423,7 @@ class ChangesPane(ListView):
         self.show_cursor = False
         self._files: list[FileStatus] = []  # Store files for access by index
         self._last_highlighted: int | None = None  # Track highlighted changes
+        self._pending_highlight_index: int | None = None  # Store index to highlight after update
     
     def update_files(self, files: list[FileStatus]) -> None:
         """Update the unstaged files list."""
@@ -440,7 +441,27 @@ class ChangesPane(ListView):
         
         # Store filtered files for access by index
         self._files = unstaged_files
-        self._last_highlighted = None  # Reset highlighting when files are updated
+        
+        # Restore highlight position if pending (after staging a file)
+        if self._pending_highlight_index is not None:
+            target_index = self._pending_highlight_index
+            # If target index is out of bounds, use the last item or 0
+            if target_index >= len(unstaged_files):
+                target_index = max(0, len(unstaged_files) - 1) if unstaged_files else None
+            if target_index is not None and target_index < len(unstaged_files):
+                # Set index and highlight after a brief delay to ensure UI is updated
+                def restore_highlight():
+                    self.index = target_index
+                    self._update_highlighting(target_index)
+                # Use call_later to ensure UI is ready
+                if hasattr(self.app, 'set_timer'):
+                    self.app.set_timer(0.1, restore_highlight)
+                else:
+                    # Fallback: set immediately
+                    restore_highlight()
+            self._pending_highlight_index = None
+        else:
+            self._last_highlighted = None  # Reset highlighting when files are updated
         
         if not unstaged_files:
             from rich.text import Text
@@ -482,6 +503,11 @@ class ChangesPane(ListView):
         # Get the file to stage
         file_status = self._files[selected_index]
         file_path = file_status.path
+        
+        # Store the current index to restore highlight after staging
+        # If we're at the last item, stay at the last item (which will be the previous one after staging)
+        # Otherwise, stay at the same index (which will be the next item after staging)
+        self._pending_highlight_index = selected_index
         
         # Get app instance and delegate to handler
         app = self.app
@@ -2630,6 +2656,9 @@ class PatchPane(Static):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.border_title = "Patch"
+        self._current_file_path: str | None = None  # Track currently displayed file
+        self._current_file_staged: bool = False  # Track if current file is staged
+        self._current_file_untracked: bool = False  # Track if current file is untracked
     
     def show_commit_info(self, commit: CommitInfo, diff_text: str, git_service=None) -> None:
         """
@@ -3206,7 +3235,7 @@ class PatchPane(Static):
     
     def show_file_info(self, file_path: str, diff_text: str, stat_text: str = "", staged: bool = False, untracked: bool = False) -> None:
         """Show file diff in the patch pane with proper color coding.
-        
+
         Args:
             file_path: Path to the file.
             diff_text: Git diff output for the file.
@@ -3214,9 +3243,14 @@ class PatchPane(Static):
             staged: Whether this is a staged diff.
             untracked: Whether the file is untracked.
         """
+        # Track current file for auto-update on stage/unstage
+        self._current_file_path = file_path
+        self._current_file_staged = staged
+        self._current_file_untracked = untracked
+        
         import re
         from rich.text import Text
-        
+
         # Create file header
         full_content = Text()
         

--- a/src/pygitzen/ui/panes.py
+++ b/src/pygitzen/ui/panes.py
@@ -341,6 +341,35 @@ class StagedPane(ListView):
         if app and hasattr(app, 'stash_actions'):
             app.stash_actions.stash_options()
     
+    def action_discard_file(self) -> None:
+        """Discard changes for the selected file.
+        
+        Shows confirmation dialog before discarding.
+        """
+        # Get selected file index
+        selected_index = self.index
+        if selected_index is None or selected_index < 0 or selected_index >= len(self._files):
+            return
+        
+        # Get the file to discard
+        file_status = self._files[selected_index]
+        file_path = file_status.path
+        
+        # For StagedPane, files are staged
+        change_type = "staged"
+        
+        # Get app instance and show confirmation dialog
+        app = self.app
+        if app:
+            from ..ui.dialogs import DiscardFileDialog
+            dialog = DiscardFileDialog(file_path, change_type=change_type, title="Discard Staged Changes")
+            
+            def handle_discard(confirmed: bool) -> None:
+                if confirmed and hasattr(app, 'file_actions'):
+                    app.file_actions.discard_file(file_path, staged=True, untracked=False)
+            
+            app.push_screen(dialog, handle_discard)
+    
     def watch_index(self, index: int | None) -> None:
         """Watch for index changes and auto-show file diff."""
         # Update highlighting for mouse clicks
@@ -566,6 +595,36 @@ class ChangesPane(ListView):
         app = self.app
         if app and hasattr(app, 'stash_actions'):
             app.stash_actions.stash_options()
+    
+    def action_discard_file(self) -> None:
+        """Discard changes for the selected file.
+        
+        Shows confirmation dialog before discarding.
+        """
+        # Get selected file index
+        selected_index = self.index
+        if selected_index is None or selected_index < 0 or selected_index >= len(self._files):
+            return
+        
+        # Get the file to discard
+        file_status = self._files[selected_index]
+        file_path = file_status.path
+        
+        # For ChangesPane, files are unstaged or untracked
+        change_type = "untracked" if file_status.status == "untracked" else "unstaged"
+        
+        # Get app instance and show confirmation dialog
+        app = self.app
+        if app:
+            from ..ui.dialogs import DiscardFileDialog
+            dialog = DiscardFileDialog(file_path, change_type=change_type, title="Discard Changes")
+            
+            def handle_discard(confirmed: bool) -> None:
+                if confirmed and hasattr(app, 'file_actions'):
+                    untracked = file_status.status == "untracked"
+                    app.file_actions.discard_file(file_path, staged=False, untracked=untracked)
+            
+            app.push_screen(dialog, handle_discard)
     
     def watch_index(self, index: int | None) -> None:
         """Watch for index changes and auto-show file diff."""

--- a/src/pygitzen/ui/panes.py
+++ b/src/pygitzen/ui/panes.py
@@ -238,6 +238,9 @@ class StagedPane(ListView):
         # Store filtered files for access by index
         self._files = staged_files
         
+        # Store original files list to check for files in both panes
+        self._all_files = files
+        
         # Restore highlight position if pending (after unstaging a file)
         if self._pending_highlight_index is not None:
             target_index = self._pending_highlight_index
@@ -288,6 +291,22 @@ class StagedPane(ListView):
             
             # Add file path
             text.append(file_status.path, style="white")
+            
+            # Check if this file also has unstaged changes (appears in both panes)
+            try:
+                # Check original files list to see if this file also has unstaged changes
+                if hasattr(self, '_all_files') and self._all_files:
+                    # Find the file in the original list
+                    for f in self._all_files:
+                        if f.path == file_status.path:
+                            # Check if it has unstaged changes
+                            if f.unstaged or (not f.staged and f.status in ["modified", "deleted"]):
+                                text.append(" [±]", style="dim white")
+                            break
+            except Exception:
+                # Silently ignore errors - don't break existing functionality
+                pass
+            
             self.append(ListItem(Static(text)))
     
     def action_toggle_stage(self) -> None:
@@ -497,6 +516,9 @@ class ChangesPane(ListView):
         # Store filtered files for access by index
         self._files = unstaged_files
         
+        # Store original files list to check for files in both panes
+        self._all_files = files
+        
         # Restore highlight position if pending (after staging a file)
         if self._pending_highlight_index is not None:
             target_index = self._pending_highlight_index
@@ -530,19 +552,38 @@ class ChangesPane(ListView):
             text = Text()
             
             # Add status indicator based on Git standard status letters
-            if file_status.status == "modified":
-                text.append("M ", style="yellow")  # Modified but not staged
-            elif file_status.status == "untracked":
+            # Check unstaged flag first, as files with both staged and unstaged changes
+            # might have status="staged" but still need "M" indicator
+            if file_status.status == "untracked":
                 text.append("U ", style="cyan")  # Untracked
             elif file_status.status == "deleted":
                 text.append("D ", style="red")  # Deleted but not staged
             elif file_status.status == "ignored":
                 text.append("! ", style="magenta")  # Ignored
+            elif file_status.unstaged or file_status.status == "modified":
+                # Show "M" for files with unstaged changes (including those with both staged and unstaged)
+                text.append("M ", style="yellow")  # Modified but not staged (or has unstaged changes)
             else:
                 text.append("  ", style="white")
             
             # Add file path
             text.append(file_status.path, style="white")
+            
+            # Check if this file also has staged changes (appears in both panes)
+            try:
+                # Check original files list to see if this file also has staged changes
+                if hasattr(self, '_all_files') and self._all_files:
+                    # Find the file in the original list
+                    for f in self._all_files:
+                        if f.path == file_status.path:
+                            # Check if it has staged changes
+                            if f.staged and f.status in ["modified", "staged", "deleted", "renamed", "copied", "submodule"]:
+                                text.append(" [±]", style="dim white")
+                            break
+            except Exception:
+                # Silently ignore errors - don't break existing functionality
+                pass
+            
             self.append(ListItem(Static(text)))
     
     def action_toggle_stage(self) -> None:

--- a/src/pygitzen/ui/panes.py
+++ b/src/pygitzen/ui/panes.py
@@ -682,6 +682,7 @@ class BranchesPane(ListView):
         super().__init__(*args, **kwargs)
         self.border_title = "Local branches"
         self._last_highlighted: int | None = None  # Track highlighted changes
+        self._pending_highlight_index: int | None = None  # Store index to highlight after update
     
     def action_new_branch(self) -> None:
         """Delegate new_branch action to the app.
@@ -746,24 +747,49 @@ class BranchesPane(ListView):
     
     def _update_highlighting(self, index: int | None) -> None:
         """Update visual highlighting by adding/removing classes."""
-        # Remove highlight from previous item
-        if self._last_highlighted is not None and self._last_highlighted < len(self.children):
-            try:
-                item = self.children[self._last_highlighted]
-                if isinstance(item, ListItem):
-                    item.remove_class("highlighted-branch")
-            except:
-                pass
+        # If index is being set (mouse click or keyboard), always show highlighting
+        # Mouse clicks should give focus, so we show highlighting even if focus check temporarily fails
+        if index is not None:
+            # If we have an index but no focus, try to get focus (mouse click should give focus)
+            if not self.has_focus:
+                try:
+                    self.focus()
+                except:
+                    pass
+            
+            # Always show highlighting when index is set (mouse click or keyboard navigation)
+            # Remove highlight from previous item
+            if self._last_highlighted is not None and self._last_highlighted < len(self.children):
+                try:
+                    item = self.children[self._last_highlighted]
+                    if isinstance(item, ListItem):
+                        item.remove_class("highlighted-branch")
+                except:
+                    pass
+            
+            # Add highlight to current item
+            if index < len(self.children):
+                try:
+                    item = self.children[index]
+                    if isinstance(item, ListItem):
+                        item.add_class("highlighted-branch")
+                        self._last_highlighted = index
+                except:
+                    pass
+            return
         
-        # Add highlight to current item
-        if index is not None and index < len(self.children):
-            try:
-                item = self.children[index]
-                if isinstance(item, ListItem):
-                    item.add_class("highlighted-branch")
-                    self._last_highlighted = index
-            except:
-                pass
+        # If index is None and no focus, remove highlighting
+        if not self.has_focus:
+            # Remove all highlighting when pane loses focus
+            if self._last_highlighted is not None and self._last_highlighted < len(self.children):
+                try:
+                    item = self.children[self._last_highlighted]
+                    if isinstance(item, ListItem):
+                        item.remove_class("highlighted-branch")
+                except:
+                    pass
+            self._last_highlighted = None
+            return
 
     def action_select(self) -> None:
         """Handle select action (Enter/Space) for branch selection.
@@ -776,26 +802,40 @@ class BranchesPane(ListView):
         if app and hasattr(app, 'action_select'):
             app.action_select()
     
-    def set_branches(self, branches: list[BranchInfo], current_branch: str, sync_status: dict[str, dict] | None = None) -> None:
+    def set_branches(self, branches: list[BranchInfo], current_branch: str, sync_status: dict[str, dict] | None = None, checked_out_branch: str | None = None) -> None:
         """Set branches with optional sync status indicators.
         
         Args:
             branches: List of branch info
-            current_branch: Name of current branch
+            current_branch: Name of currently selected/active branch (for UI)
             sync_status: Optional dict mapping branch name to sync status dict with keys:
                 'behind', 'ahead', 'synced', 'upstream'
+            checked_out_branch: Name of actually checked-out branch (for '*' indicator)
         """
+        # Preserve current index before clearing (to restore highlighting after update)
+        current_index = self.index if hasattr(self, 'index') else None
+        current_highlighted = self.highlighted if hasattr(self, 'highlighted') else None
+        preserve_index = current_index if current_index is not None else current_highlighted
+        
         self.clear()
-        self._last_highlighted = None  # Reset highlighting when branches are updated
+        
+        # Restore highlighting after update if we had a selection
+        if preserve_index is not None:
+            self._pending_highlight_index = preserve_index
+        else:
+            self._last_highlighted = None  # Reset highlighting when branches are updated
         if sync_status is None:
             sync_status = {}
+        
+        # Use checked_out_branch for '*' indicator if provided, otherwise fall back to current_branch
+        branch_for_indicator = checked_out_branch if checked_out_branch else current_branch
         
         for branch in branches:
             from rich.text import Text
             text = Text()
             
-            # Current branch indicator
-            if branch.name == current_branch:
+            # Current branch indicator - only show '*' for actually checked-out branch
+            if branch.name == branch_for_indicator:
                 text.append("* ", style="green")
             else:
                 text.append("  ", style="white")
@@ -835,6 +875,26 @@ class BranchesPane(ListView):
             if branch.name == current_branch:
                 item.add_class("current-branch")
             self.append(item)
+        
+        # Restore highlight position if pending (after set_branches update)
+        if self._pending_highlight_index is not None:
+            target_index = self._pending_highlight_index
+            # If target index is out of bounds, use the last item or 0
+            if target_index >= len(branches):
+                target_index = max(0, len(branches) - 1) if branches else None
+            if target_index is not None and target_index < len(branches):
+                # Set index and highlight after a brief delay to ensure UI is updated
+                def restore_highlight():
+                    self.index = target_index
+                    self.highlighted = target_index
+                    self._update_highlighting(target_index)
+                # Use call_later to ensure UI is ready
+                if hasattr(self.app, 'set_timer'):
+                    self.app.set_timer(0.1, restore_highlight)
+                else:
+                    # Fallback: set immediately
+                    restore_highlight()
+            self._pending_highlight_index = None
 
 
 

--- a/src/pygitzen/ui/panes.py
+++ b/src/pygitzen/ui/panes.py
@@ -312,6 +312,29 @@ class StagedPane(ListView):
         app = self.app
         if app and hasattr(app, 'stash_actions'):
             app.stash_actions.stash_options()
+    
+    def watch_index(self, index: int | None) -> None:
+        """Watch for index changes and auto-show file diff."""
+        if index is not None and 0 <= index < len(self._files):
+            file_status = self._files[index]
+            file_path = file_status.path
+            
+            # Determine if file is staged and untracked
+            staged = file_status.staged
+            untracked = file_status.status == "untracked"
+            
+            # Get app instance and show file diff
+            app = self.app
+            if app and hasattr(app, 'file_actions'):
+                # Switch to patch view
+                if hasattr(app, '_view_mode'):
+                    app._view_mode = "patch"
+                if hasattr(app, 'patch_pane') and hasattr(app, 'log_pane'):
+                    app.patch_pane.styles.display = "block"
+                    app.log_pane.styles.display = "none"
+                
+                # Show file diff
+                app.file_actions.show_file_diff(file_path, staged=staged, untracked=untracked)
 
 
 
@@ -417,6 +440,29 @@ class ChangesPane(ListView):
         app = self.app
         if app and hasattr(app, 'stash_actions'):
             app.stash_actions.stash_options()
+    
+    def watch_index(self, index: int | None) -> None:
+        """Watch for index changes and auto-show file diff."""
+        if index is not None and 0 <= index < len(self._files):
+            file_status = self._files[index]
+            file_path = file_status.path
+            
+            # Determine if file is staged and untracked
+            staged = file_status.staged
+            untracked = file_status.status == "untracked"
+            
+            # Get app instance and show file diff
+            app = self.app
+            if app and hasattr(app, 'file_actions'):
+                # Switch to patch view
+                if hasattr(app, '_view_mode'):
+                    app._view_mode = "patch"
+                if hasattr(app, 'patch_pane') and hasattr(app, 'log_pane'):
+                    app.patch_pane.styles.display = "block"
+                    app.log_pane.styles.display = "none"
+                
+                # Show file diff
+                app.file_actions.show_file_diff(file_path, staged=staged, untracked=untracked)
 
 
 
@@ -2928,6 +2974,108 @@ class PatchPane(Static):
         else:
             # No diff available
             full_content.append("No diff available\n", style="dim white")
+        
+        self.update(full_content)
+    
+    def show_file_info(self, file_path: str, diff_text: str, stat_text: str = "", staged: bool = False, untracked: bool = False) -> None:
+        """Show file diff in the patch pane with proper color coding.
+        
+        Args:
+            file_path: Path to the file.
+            diff_text: Git diff output for the file.
+            stat_text: Git diff stat output (optional).
+            staged: Whether this is a staged diff.
+            untracked: Whether the file is untracked.
+        """
+        import re
+        from rich.text import Text
+        
+        # Create file header
+        full_content = Text()
+        
+        # Determine status label
+        if untracked:
+            status_label = "Untracked"
+        elif staged:
+            status_label = "Staged Changes"
+        else:
+            status_label = "Unstaged Changes"
+        
+        # File header: file_path (Status)
+        full_content.append(f"{file_path} ({status_label})\n", style="yellow")
+        full_content.append("\n", style="white")
+        
+        # Strip ANSI codes from stat and diff
+        stat_text_clean = re.sub(r'\x1b\[[0-9;]*m', '', stat_text) if stat_text else ""
+        diff_text_clean = re.sub(r'\x1b\[[0-9;]*m', '', diff_text) if diff_text else ""
+        
+        # Add stat summary if available
+        if stat_text_clean:
+            stat_lines = stat_text_clean.split('\n')
+            for line in stat_lines:
+                cleaned_line = line.lstrip()
+                if not cleaned_line:
+                    full_content.append("\n", style="white")
+                    continue
+                
+                # Check if this is a diffstat file line
+                if '|' in cleaned_line and ('+' in cleaned_line or '-' in cleaned_line):
+                    # Extract file name and stats
+                    parts = cleaned_line.split('|')
+                    if len(parts) >= 2:
+                        filename = parts[0].strip()
+                        stats = parts[1].strip()
+                        full_content.append(f"{filename} |", style="cyan")
+                        # Color code the stats
+                        if '+' in stats:
+                            full_content.append(f" {stats}\n", style="green")
+                        elif '-' in stats:
+                            full_content.append(f" {stats}\n", style="red")
+                        else:
+                            full_content.append(f" {stats}\n", style="white")
+                elif cleaned_line.startswith(" ") and ('file' in cleaned_line.lower() and 'changed' in cleaned_line.lower()):
+                    # Summary line like " 3 files changed, 5 insertions(+), 2 deletions(-)"
+                    full_content.append(f"{cleaned_line}\n", style="dim white")
+                else:
+                    full_content.append(f"{cleaned_line}\n", style="white")
+            
+            full_content.append("\n", style="white")
+        
+        # Add diff content with proper color coding
+        if diff_text_clean:
+            diff_lines = diff_text_clean.split('\n')
+            for line in diff_lines:
+                if not line:
+                    full_content.append("\n", style="white")
+                    continue
+                
+                # Color code diff lines
+                if line.startswith('+++') or line.startswith('---'):
+                    full_content.append(line + '\n', style="cyan")
+                elif line.startswith('@@'):
+                    # Hunk header
+                    full_content.append(line + '\n', style="blue")
+                elif line.startswith('+') and not line.startswith('+++'):
+                    # Added line
+                    full_content.append(line + '\n', style="green")
+                elif line.startswith('-') and not line.startswith('---'):
+                    # Removed line
+                    full_content.append(line + '\n', style="red")
+                elif line.startswith('diff --git'):
+                    full_content.append(line + '\n', style="cyan")
+                elif line.startswith('index '):
+                    full_content.append(line + '\n', style="dim white")
+                elif line.startswith('new file mode') or line.startswith('deleted file mode'):
+                    full_content.append(line + '\n', style="dim white")
+                else:
+                    # Context line
+                    full_content.append(line + '\n', style="white")
+        else:
+            # No diff available
+            if untracked:
+                full_content.append("New file (no diff available)\n", style="dim white")
+            else:
+                full_content.append("No diff available\n", style="dim white")
         
         self.update(full_content)
 

--- a/src/pygitzen/ui/panes.py
+++ b/src/pygitzen/ui/panes.py
@@ -853,25 +853,52 @@ class RemotesPane(ListView):
     
     def watch_highlighted(self, highlighted: int | None) -> None:
         """Watch for highlighted changes (arrow keys) to update visual highlighting."""
-        if highlighted is not None:
-            # Remove highlight from previous item
-            if self._last_highlighted is not None and self._last_highlighted < len(self.children):
-                try:
-                    item = self.children[self._last_highlighted]
-                    if isinstance(item, ListItem):
-                        item.remove_class("highlighted-remote")
-                except:
-                    pass
-            
-            # Add highlight to current item
-            if highlighted < len(self.children):
-                try:
-                    item = self.children[highlighted]
-                    if isinstance(item, ListItem):
-                        item.add_class("highlighted-remote")
-                        self._last_highlighted = highlighted
-                except:
-                    pass
+        # Update highlighting
+        self._update_highlighting(highlighted)
+        
+        # Scroll to highlighted item to ensure it's visible
+        try:
+            if highlighted is not None and highlighted < len(self.children):
+                item = self.children[highlighted]
+                if isinstance(item, ListItem):
+                    self.scroll_to_widget(item, animate=False)
+        except Exception:
+            pass
+    
+    def watch_index(self, index: int | None) -> None:
+        """Watch for index changes to update visual highlighting."""
+        # Update highlighting for mouse clicks
+        self._update_highlighting(index)
+        
+        # Scroll to selected item to ensure it's visible
+        try:
+            if index is not None and index < len(self.children):
+                item = self.children[index]
+                if isinstance(item, ListItem):
+                    self.scroll_to_widget(item, animate=False)
+        except Exception:
+            pass
+    
+    def _update_highlighting(self, index: int | None) -> None:
+        """Update visual highlighting by adding/removing classes."""
+        # Remove highlight from previous item
+        if self._last_highlighted is not None and self._last_highlighted < len(self.children):
+            try:
+                item = self.children[self._last_highlighted]
+                if isinstance(item, ListItem):
+                    item.remove_class("highlighted-remote")
+            except:
+                pass
+        
+        # Add highlight to current item
+        if index is not None and index < len(self.children):
+            try:
+                item = self.children[index]
+                if isinstance(item, ListItem):
+                    item.add_class("highlighted-remote")
+                    self._last_highlighted = index
+            except:
+                pass
     
     def set_on_render_to_main(self, callback: callable) -> None:
         """Set callback for automatic patch updates (lazygit GetOnRenderToMain pattern)."""
@@ -880,6 +907,7 @@ class RemotesPane(ListView):
     def set_remotes(self, remotes: list[BranchInfo]) -> None:
         self.clear()
         self._remotes = remotes  # Store remotes for selection access
+        self._last_highlighted = None  # Reset highlighting when remotes are updated
         
         for remote in remotes:
             from rich.text import Text
@@ -935,25 +963,52 @@ class TagsPane(ListView):
     
     def watch_highlighted(self, highlighted: int | None) -> None:
         """Watch for highlighted changes (arrow keys) to update visual highlighting."""
-        if highlighted is not None:
-            # Remove highlight from previous item
-            if self._last_highlighted is not None and self._last_highlighted < len(self.children):
-                try:
-                    item = self.children[self._last_highlighted]
-                    if isinstance(item, ListItem):
-                        item.remove_class("highlighted-tag")
-                except:
-                    pass
-            
-            # Add highlight to current item
-            if highlighted < len(self.children):
-                try:
-                    item = self.children[highlighted]
-                    if isinstance(item, ListItem):
-                        item.add_class("highlighted-tag")
-                        self._last_highlighted = highlighted
-                except:
-                    pass
+        # Update highlighting
+        self._update_highlighting(highlighted)
+        
+        # Scroll to highlighted item to ensure it's visible
+        try:
+            if highlighted is not None and highlighted < len(self.children):
+                item = self.children[highlighted]
+                if isinstance(item, ListItem):
+                    self.scroll_to_widget(item, animate=False)
+        except Exception:
+            pass
+    
+    def watch_index(self, index: int | None) -> None:
+        """Watch for index changes to update visual highlighting."""
+        # Update highlighting for mouse clicks
+        self._update_highlighting(index)
+        
+        # Scroll to selected item to ensure it's visible
+        try:
+            if index is not None and index < len(self.children):
+                item = self.children[index]
+                if isinstance(item, ListItem):
+                    self.scroll_to_widget(item, animate=False)
+        except Exception:
+            pass
+    
+    def _update_highlighting(self, index: int | None) -> None:
+        """Update visual highlighting by adding/removing classes."""
+        # Remove highlight from previous item
+        if self._last_highlighted is not None and self._last_highlighted < len(self.children):
+            try:
+                item = self.children[self._last_highlighted]
+                if isinstance(item, ListItem):
+                    item.remove_class("highlighted-tag")
+            except:
+                pass
+        
+        # Add highlight to current item
+        if index is not None and index < len(self.children):
+            try:
+                item = self.children[index]
+                if isinstance(item, ListItem):
+                    item.add_class("highlighted-tag")
+                    self._last_highlighted = index
+            except:
+                pass
     
     def set_on_render_to_main(self, callback: callable) -> None:
         """Set callback for automatic patch updates (lazygit GetOnRenderToMain pattern)."""
@@ -970,6 +1025,7 @@ class TagsPane(ListView):
         if not append:
             self.clear()
             self._tags = []
+            self._last_highlighted = None  # Reset highlighting when tags are updated
             self._loaded_tags_count = 0
             self._rendered_count = 0  # Reset rendered count on initial load
             # Store initial tags and set total count

--- a/src/pygitzen/ui/panes.py
+++ b/src/pygitzen/ui/panes.py
@@ -1811,11 +1811,11 @@ class CommitsPane(ListView):
         # Mouse clicks should give focus, so we show highlighting even if focus check temporarily fails
         if index is not None:
             # If we have an index but no focus, try to get focus (mouse click should give focus)
-            if not self.has_focus:
-                try:
-                    self.focus()
-                except:
-                    pass
+            # if not self.has_focus:
+            #     try:
+            #         self.focus()
+            #     except:
+            #         pass
             
             # Always show highlighting when index is set (mouse click or keyboard navigation)
             # Remove highlight from previous item

--- a/src/pygitzen/ui/panes.py
+++ b/src/pygitzen/ui/panes.py
@@ -511,7 +511,38 @@ class StagedPane(ListView):
     
     def _update_highlighting(self, index: int | None) -> None:
         """Update visual highlighting by adding/removing classes."""
-        # Only show highlighting when pane has focus
+        # If index is being set (mouse click or keyboard), always show highlighting
+        # Mouse clicks should give focus, so we show highlighting even if focus check temporarily fails
+        if index is not None:
+            # If we have an index but no focus, try to get focus (mouse click should give focus)
+            if not self.has_focus:
+                try:
+                    self.focus()
+                except:
+                    pass
+            
+            # Always show highlighting when index is set (mouse click or keyboard navigation)
+            # Remove highlight from previous item
+            if self._last_highlighted is not None and self._last_highlighted < len(self.children):
+                try:
+                    item = self.children[self._last_highlighted]
+                    if isinstance(item, ListItem):
+                        item.remove_class("highlighted-file")
+                except:
+                    pass
+            
+            # Add highlight to current item
+            if index < len(self.children):
+                try:
+                    item = self.children[index]
+                    if isinstance(item, ListItem):
+                        item.add_class("highlighted-file")
+                        self._last_highlighted = index
+                except:
+                    pass
+            return
+        
+        # If index is None and no focus, remove highlighting
         if not self.has_focus:
             # Remove all highlighting when pane loses focus
             if self._last_highlighted is not None and self._last_highlighted < len(self.children):
@@ -523,7 +554,7 @@ class StagedPane(ListView):
                     pass
             return
         
-        # Remove highlight from previous item
+        # Remove highlight from previous item (fallback for when index is None but pane has focus)
         if self._last_highlighted is not None and self._last_highlighted < len(self.children):
             try:
                 item = self.children[self._last_highlighted]
@@ -531,25 +562,25 @@ class StagedPane(ListView):
                     item.remove_class("highlighted-file")
             except:
                 pass
-        
-        # Add highlight to current item
-        if index is not None and index < len(self.children):
-            try:
-                item = self.children[index]
-                if isinstance(item, ListItem):
-                    item.add_class("highlighted-file")
-                    self._last_highlighted = index
-            except:
-                pass
     
     def on_focus(self) -> None:
         """Handle pane gaining focus - restore highlighting and auto-show file diff."""
         # Restore highlighting if we have a highlighted item
-        # Prefer _last_highlighted over highlighted to preserve selection across focus changes
-        current_index = self._last_highlighted if self._last_highlighted is not None else (self.highlighted if hasattr(self, 'highlighted') and self.highlighted is not None else None)
+        # Priority: self.index (set by Textual on click) > _last_highlighted > highlighted
+        # This ensures mouse clicks are respected even if on_focus() runs before watch_index()
+        current_index = None
+        if hasattr(self, 'index') and self.index is not None:
+            current_index = self.index
+        elif self._last_highlighted is not None:
+            current_index = self._last_highlighted
+        elif hasattr(self, 'highlighted') and self.highlighted is not None:
+            current_index = self.highlighted
+        
+        # Check if we're defaulting to 0 (no valid index found)
+        is_defaulting_to_zero = current_index is None and len(self._files) > 0
         
         # If no item is highlighted and pane has items, highlight the first one
-        if current_index is None and len(self._files) > 0:
+        if is_defaulting_to_zero:
             current_index = 0
         
         # Set both highlighted and index to ensure ListView knows which item is selected
@@ -558,11 +589,27 @@ class StagedPane(ListView):
             self.index = current_index
             # Update _last_highlighted to preserve selection
             self._last_highlighted = current_index
-            # Use set_timer with minimal delay to ensure highlighting happens after focus is fully established
-            try:
-                self.set_timer(0.01, lambda: self._update_highlighting(current_index))
-            except:
-                # Fallback: call directly if timer not available
+            
+            # If we're defaulting to 0, delay highlighting slightly to let watch_index() run first
+            # This prevents the flash of item 0 when clicking on a different item
+            if is_defaulting_to_zero:
+                # Use a small delay to let watch_index() run first if user clicked an item
+                # Store the intended index to check if it's still valid when timer fires
+                intended_index = current_index
+                def delayed_highlight():
+                    # Only highlight if watch_index() hasn't already set a different index
+                    # Check if _last_highlighted matches our intended index (0)
+                    # If watch_index() ran, _last_highlighted will be different
+                    if self._last_highlighted == intended_index:
+                        self._update_highlighting(intended_index)
+                
+                try:
+                    self.set_timer(0.01, delayed_highlight)
+                except:
+                    # Fallback: call directly if timer not available
+                    self._update_highlighting(current_index)
+            else:
+                # Apply highlighting immediately for existing selections
                 self._update_highlighting(current_index)
             
             # Auto-show file diff for the highlighted item
@@ -906,7 +953,38 @@ class ChangesPane(ListView):
     
     def _update_highlighting(self, index: int | None) -> None:
         """Update visual highlighting by adding/removing classes."""
-        # Only show highlighting when pane has focus
+        # If index is being set (mouse click or keyboard), always show highlighting
+        # Mouse clicks should give focus, so we show highlighting even if focus check temporarily fails
+        if index is not None:
+            # If we have an index but no focus, try to get focus (mouse click should give focus)
+            if not self.has_focus:
+                try:
+                    self.focus()
+                except:
+                    pass
+            
+            # Always show highlighting when index is set (mouse click or keyboard navigation)
+            # Remove highlight from previous item
+            if self._last_highlighted is not None and self._last_highlighted < len(self.children):
+                try:
+                    item = self.children[self._last_highlighted]
+                    if isinstance(item, ListItem):
+                        item.remove_class("highlighted-file")
+                except:
+                    pass
+            
+            # Add highlight to current item
+            if index < len(self.children):
+                try:
+                    item = self.children[index]
+                    if isinstance(item, ListItem):
+                        item.add_class("highlighted-file")
+                        self._last_highlighted = index
+                except:
+                    pass
+            return
+        
+        # If index is None and no focus, remove highlighting
         if not self.has_focus:
             # Remove all highlighting when pane loses focus
             if self._last_highlighted is not None and self._last_highlighted < len(self.children):
@@ -918,7 +996,7 @@ class ChangesPane(ListView):
                     pass
             return
         
-        # Remove highlight from previous item
+        # Remove highlight from previous item (fallback for when index is None but pane has focus)
         if self._last_highlighted is not None and self._last_highlighted < len(self.children):
             try:
                 item = self.children[self._last_highlighted]
@@ -926,25 +1004,25 @@ class ChangesPane(ListView):
                     item.remove_class("highlighted-file")
             except:
                 pass
-        
-        # Add highlight to current item
-        if index is not None and index < len(self.children):
-            try:
-                item = self.children[index]
-                if isinstance(item, ListItem):
-                    item.add_class("highlighted-file")
-                    self._last_highlighted = index
-            except:
-                pass
     
     def on_focus(self) -> None:
         """Handle pane gaining focus - restore highlighting and auto-show file diff."""
         # Restore highlighting if we have a highlighted item
-        # Prefer _last_highlighted over highlighted to preserve selection across focus changes
-        current_index = self._last_highlighted if self._last_highlighted is not None else (self.highlighted if hasattr(self, 'highlighted') and self.highlighted is not None else None)
+        # Priority: self.index (set by Textual on click) > _last_highlighted > highlighted
+        # This ensures mouse clicks are respected even if on_focus() runs before watch_index()
+        current_index = None
+        if hasattr(self, 'index') and self.index is not None:
+            current_index = self.index
+        elif self._last_highlighted is not None:
+            current_index = self._last_highlighted
+        elif hasattr(self, 'highlighted') and self.highlighted is not None:
+            current_index = self.highlighted
+        
+        # Check if we're defaulting to 0 (no valid index found)
+        is_defaulting_to_zero = current_index is None and len(self._files) > 0
         
         # If no item is highlighted and pane has items, highlight the first one
-        if current_index is None and len(self._files) > 0:
+        if is_defaulting_to_zero:
             current_index = 0
         
         # Set both highlighted and index to ensure ListView knows which item is selected
@@ -953,11 +1031,27 @@ class ChangesPane(ListView):
             self.index = current_index
             # Update _last_highlighted to preserve selection
             self._last_highlighted = current_index
-            # Use set_timer with minimal delay to ensure highlighting happens after focus is fully established
-            try:
-                self.set_timer(0.01, lambda: self._update_highlighting(current_index))
-            except:
-                # Fallback: call directly if timer not available
+            
+            # If we're defaulting to 0, delay highlighting slightly to let watch_index() run first
+            # This prevents the flash of item 0 when clicking on a different item
+            if is_defaulting_to_zero:
+                # Use a small delay to let watch_index() run first if user clicked an item
+                # Store the intended index to check if it's still valid when timer fires
+                intended_index = current_index
+                def delayed_highlight():
+                    # Only highlight if watch_index() hasn't already set a different index
+                    # Check if _last_highlighted matches our intended index (0)
+                    # If watch_index() ran, _last_highlighted will be different
+                    if self._last_highlighted == intended_index:
+                        self._update_highlighting(intended_index)
+                
+                try:
+                    self.set_timer(0.01, delayed_highlight)
+                except:
+                    # Fallback: call directly if timer not available
+                    self._update_highlighting(current_index)
+            else:
+                # Apply highlighting immediately for existing selections
                 self._update_highlighting(current_index)
             
             # Auto-show file diff for the highlighted item
@@ -1713,7 +1807,38 @@ class CommitsPane(ListView):
     
     def _update_highlighting(self, index: int | None) -> None:
         """Update visual highlighting by adding/removing classes."""
-        # Only show highlighting when pane has focus
+        # If index is being set (mouse click or keyboard), always show highlighting
+        # Mouse clicks should give focus, so we show highlighting even if focus check temporarily fails
+        if index is not None:
+            # If we have an index but no focus, try to get focus (mouse click should give focus)
+            if not self.has_focus:
+                try:
+                    self.focus()
+                except:
+                    pass
+            
+            # Always show highlighting when index is set (mouse click or keyboard navigation)
+            # Remove highlight from previous item
+            if self._last_highlighted is not None and self._last_highlighted < len(self.children):
+                try:
+                    item = self.children[self._last_highlighted]
+                    if isinstance(item, ListItem):
+                        item.remove_class("highlighted-commit")
+                except:
+                    pass
+            
+            # Add highlight to current item
+            if index < len(self.children):
+                try:
+                    item = self.children[index]
+                    if isinstance(item, ListItem):
+                        item.add_class("highlighted-commit")
+                        self._last_highlighted = index
+                except:
+                    pass
+            return
+        
+        # If index is None and no focus, remove highlighting
         if not self.has_focus:
             # Remove all highlighting when pane loses focus
             if self._last_highlighted is not None and self._last_highlighted < len(self.children):
@@ -1725,7 +1850,7 @@ class CommitsPane(ListView):
                     pass
             return
         
-        # Remove highlight from previous item
+        # Remove highlight from previous item (fallback for when index is None but pane has focus)
         if self._last_highlighted is not None and self._last_highlighted < len(self.children):
             try:
                 item = self.children[self._last_highlighted]
@@ -1733,30 +1858,30 @@ class CommitsPane(ListView):
                     item.remove_class("highlighted-commit")
             except:
                 pass
-        
-        # Add highlight to current item
-        if index is not None and index < len(self.children):
-            try:
-                item = self.children[index]
-                if isinstance(item, ListItem):
-                    item.add_class("highlighted-commit")
-                    self._last_highlighted = index
-            except:
-                pass
     
     def on_focus(self) -> None:
         """Handle pane gaining focus - restore highlighting and auto-show commit patch."""
         # Restore highlighting if we have a highlighted item
-        # Prefer _last_highlighted over highlighted to preserve selection across focus changes
-        current_index = self._last_highlighted if self._last_highlighted is not None else (self.highlighted if hasattr(self, 'highlighted') and self.highlighted is not None else None)
+        # Priority: self.index (set by Textual on click) > _last_highlighted > highlighted
+        # This ensures mouse clicks are respected even if on_focus() runs before watch_index()
+        current_index = None
+        if hasattr(self, 'index') and self.index is not None:
+            current_index = self.index
+        elif self._last_highlighted is not None:
+            current_index = self._last_highlighted
+        elif hasattr(self, 'highlighted') and self.highlighted is not None:
+            current_index = self.highlighted
         
         # Get commits from parent app
         commits = []
         if self._parent_app and hasattr(self._parent_app, 'commits'):
             commits = self._parent_app.commits
         
+        # Check if we're defaulting to 0 (no valid index found)
+        is_defaulting_to_zero = current_index is None and len(commits) > 0
+        
         # If no item is highlighted and pane has items, highlight the first one
-        if current_index is None and len(commits) > 0:
+        if is_defaulting_to_zero:
             current_index = 0
         
         # Set both highlighted and index to ensure ListView knows which item is selected
@@ -1765,11 +1890,27 @@ class CommitsPane(ListView):
             self.index = current_index
             # Update _last_highlighted to preserve selection
             self._last_highlighted = current_index
-            # Use set_timer with minimal delay to ensure highlighting happens after focus is fully established
-            try:
-                self.set_timer(0.01, lambda: self._update_highlighting(current_index))
-            except:
-                # Fallback: call directly if timer not available
+            
+            # If we're defaulting to 0, delay highlighting slightly to let watch_index() run first
+            # This prevents the flash of item 0 when clicking on a different item
+            if is_defaulting_to_zero:
+                # Use a small delay to let watch_index() run first if user clicked an item
+                # Store the intended index to check if it's still valid when timer fires
+                intended_index = current_index
+                def delayed_highlight():
+                    # Only highlight if watch_index() hasn't already set a different index
+                    # Check if _last_highlighted matches our intended index (0)
+                    # If watch_index() ran, _last_highlighted will be different
+                    if self._last_highlighted == intended_index:
+                        self._update_highlighting(intended_index)
+                
+                try:
+                    self.set_timer(0.01, delayed_highlight)
+                except:
+                    # Fallback: call directly if timer not available
+                    self._update_highlighting(current_index)
+            else:
+                # Apply highlighting immediately for existing selections
                 self._update_highlighting(current_index)
             
             # Auto-show commit patch for the highlighted item


### PR DESCRIPTION
## Summary
Fixes initial focus behavior by removing CommitsPane auto-focus and explicitly focusing branches pane on app load.

## Changes
- Removed auto-focus call in `CommitsPane._update_highlighting()` 
- Added explicit `branches_pane.focus()` in `on_mount()`

## Impact
- Branches pane now receives focus on app load (instead of staged pane)
- More predictable focus behavior
- Commits pane no longer steals focus when commits are loaded